### PR TITLE
refactor(inject): Remove reflect-metadata

### DIFF
--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/furystack/furystack",
   "dependencies": {
     "@furystack/utils": "^1.1.17",
-    "reflect-metadata": "^0.1.13",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/inject/src/injectable.ts
+++ b/packages/inject/src/injectable.ts
@@ -1,6 +1,7 @@
-import 'reflect-metadata'
 import { Injector } from './injector'
 import { Constructable } from './types/constructable'
+
+import './reflect-metadata-polyfill'
 
 /**
  * Options for the injectable instance

--- a/packages/inject/src/reflect-metadata-polyfill.ts
+++ b/packages/inject/src/reflect-metadata-polyfill.ts
@@ -1,0 +1,42 @@
+/* eslint-disable no-redeclare */
+/* eslint-disable @typescript-eslint/no-namespace */
+import { Constructable } from './types/constructable'
+
+declare global {
+  namespace Reflect {
+    export function decorate<T>(decorators: ClassDecorator[], target: Constructable<T>): Constructable<T>
+    export function metadata<T>(key: any, value: any): any
+    export function getMetadata(metadataKey: 'design:paramtypes', target: any): any
+  }
+}
+
+const classDecoratorsMap = new Map<Constructable<any>, any>()
+
+if (typeof Reflect.decorate !== 'function') {
+  Reflect.decorate = (decorators, target) => {
+    classDecoratorsMap.set(target, decorators)
+    const returnTarget = decorators.reduce((prev, current) => {
+      if (typeof current === 'function') {
+        const updated = current(prev)
+        if (updated && typeof updated === typeof prev) {
+          return updated
+        }
+      }
+      return prev
+    }, target)
+    return returnTarget
+  }
+}
+
+if (typeof Reflect.metadata !== 'function') {
+  Reflect.metadata = (key, value) => {
+    return { key, value }
+  }
+}
+
+if (typeof Reflect.getMetadata !== 'function') {
+  Reflect.getMetadata = (metadataKey, target) => {
+    const value = classDecoratorsMap.get(target)?.find((v: any) => v.key === metadataKey)?.value || []
+    return value
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6732,11 +6732,6 @@ redis@^3.0.2:
     redis-errors "^1.2.0"
     redis-parser "^3.0.0"
 
-reflect-metadata@^0.1.13:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
-  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
-
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"


### PR DESCRIPTION
As reflect-metadata is one of the largest dependency in one of the base packages (inject) and we use only a small subset of it, we should try to remove it with a more simple and lightweight solution.
