### PR TITLE
feature/observable dispose throws

### DIFF
--- a/.yarn/versions/8a6463fe.yml
+++ b/.yarn/versions/8a6463fe.yml
@@ -1,5 +1,22 @@
 releases:
+  "@furystack/auth-google": patch
+  "@furystack/core": patch
+  "@furystack/filesystem-store": patch
+  "@furystack/inject": patch
+  "@furystack/logging": patch
   "@furystack/mongodb-store": patch
   "@furystack/redis-store": patch
+  "@furystack/repository": patch
+  "@furystack/rest": patch
+  "@furystack/rest-client-fetch": patch
+  "@furystack/rest-client-got": patch
+  "@furystack/rest-service": patch
+  "@furystack/security": patch
   "@furystack/sequelize-store": patch
+  "@furystack/shades": patch
+  "@furystack/shades-common-components": patch
+  "@furystack/shades-lottie": patch
+  "@furystack/shades-nipple": patch
+  "@furystack/utils": minor
+  "@furystack/websocket-api": patch
   furystack: patch

--- a/packages/utils/src/observable-value.spec.ts
+++ b/packages/utils/src/observable-value.spec.ts
@@ -87,6 +87,18 @@ export const observableTests = describe('Observable', () => {
       expect(v.getObservers().length).toBe(0)
     })
 
+    it('should throw an error for setValue() when the observer has been disposed', () => {
+      const v = new ObservableValue(1)
+      v.dispose()
+      expect(() => v.setValue(3)).toThrowError('ObservableValue is already disposed')
+    })
+
+    it('should throw an error for setValue() when the observer has been disposed', () => {
+      const v = new ObservableValue(1)
+      v.dispose()
+      expect(() => v.getValue()).toThrowError('ObservableValue is already disposed')
+    })
+
     it('should remove the subscription only from the disposed Observer', (done) => {
       class Alma {
         public Callback() {

--- a/packages/utils/src/observable-value.ts
+++ b/packages/utils/src/observable-value.ts
@@ -28,11 +28,18 @@ export type ValueChangeCallback<T> = (next: T) => void
  * @param T Generic argument to indicate the value type
  */
 export class ObservableValue<T> implements Disposable {
+  public get isDisposed(): boolean {
+    return this._isDisposed
+  }
+
+  private _isDisposed = false
+
   /**
    * Disposes the ObservableValue object, removes all observers
    */
   public dispose() {
     this.observers.clear()
+    this._isDisposed = true
   }
   private observers: Set<ValueObserver<T>> = new Set()
   private currentValue!: T
@@ -69,6 +76,9 @@ export class ObservableValue<T> implements Disposable {
    * @returns The current value
    */
   public getValue(): T {
+    if (this._isDisposed) {
+      throw new Error('ObservableValue is already disposed')
+    }
     return this.currentValue
   }
 
@@ -78,6 +88,9 @@ export class ObservableValue<T> implements Disposable {
    * @param newValue The new value to be set
    */
   public setValue(newValue: T) {
+    if (this._isDisposed) {
+      throw new Error('ObservableValue is already disposed')
+    }
     if (this.currentValue !== newValue) {
       this.currentValue = newValue
       for (const subscription of this.observers) {


### PR DESCRIPTION
Observables should throw an error when they has been disposed and the `getValue()` or `setValue()` has been called