### PR TITLE
Feat/collection service id reconciliation

### DIFF
--- a/.yarn/changelogs/@furystack-shades-common-components.35b36e52.md
+++ b/.yarn/changelogs/@furystack-shades-common-components.35b36e52.md
@@ -1,4 +1,4 @@
-<!-- version-type: patch -->
+<!-- version-type: minor -->
 
 # @furystack/shades-common-components
 

--- a/.yarn/changelogs/@furystack-shades-common-components.35b36e52.md
+++ b/.yarn/changelogs/@furystack-shades-common-components.35b36e52.md
@@ -1,0 +1,71 @@
+<!-- version-type: patch -->
+
+# @furystack/shades-common-components
+
+## ✨ Features
+
+### Automatic reference reconciliation in `CollectionService` via `idField`
+
+`CollectionServiceOptions` now accepts an optional `idField` that identifies a stable identity key on entries. When provided, `CollectionService` subscribes to its own `data` observable and automatically reconciles `focusedEntry` and `selection` against the new entries array whenever `data` changes, swapping stale object references for their matching counterparts by id.
+
+This keeps keyboard navigation (arrow keys, selection toggles, select-all) and the currently focused/selected rows working correctly when the backing data array is rebuilt with new object instances (e.g. after a refetch), instead of silently breaking because the held references no longer exist in the new array.
+
+**Usage:**
+
+```typescript
+import { CollectionService } from '@furystack/shades-common-components'
+
+interface User {
+  id: string
+  name: string
+}
+
+const service = new CollectionService<User>({ idField: 'id' })
+
+service.data.setValue({ count: users.length, entries: users })
+service.focusedEntry.setValue(users[1])
+
+// Later, after a refetch that returns new object instances with the same ids:
+service.data.setValue({ count: refetched.length, entries: refetched })
+
+// focusedEntry and selection now point at the matching entries in `refetched`
+// instead of the stale objects from the previous data set.
+```
+
+Entries whose id is no longer present in the new data are dropped from `selection`, and `focusedEntry` is cleared if its id disappeared. The feature is opt-in: if `idField` is not set, the previous behavior is preserved unchanged.
+
+## 🐛 Bug Fixes
+
+<!-- PLACEHOLDER: Describe the nasty little bugs that has been eradicated (fix:) -->
+
+## 📚 Documentation
+
+<!-- PLACEHOLDER: Describe documentation changes (docs:) -->
+
+## ⚡ Performance
+
+<!-- PLACEHOLDER: Describe performance improvements (perf:) -->
+
+## ♻️ Refactoring
+
+<!-- PLACEHOLDER: Describe code refactoring (refactor:) -->
+
+## 🧪 Tests
+
+- Added unit tests for `CollectionService` `idField` reconciliation, covering `focusedEntry` and `selection` updates on data changes, removal of stale entries, no-op behavior when `idField` is absent, reference-equality short-circuit, and end-to-end keyboard navigation after a data refresh.
+
+## 📦 Build
+
+<!-- PLACEHOLDER: Describe build system changes (build:) -->
+
+## 👷 CI
+
+<!-- PLACEHOLDER: Describe CI configuration changes (ci:) -->
+
+## ⬆️ Dependencies
+
+<!-- PLACEHOLDER: Describe dependency updates (deps:) -->
+
+## 🔧 Chores
+
+<!-- PLACEHOLDER: Describe other changes (chore:) -->

--- a/.yarn/changelogs/@furystack-shades-showcase-app.35b36e52.md
+++ b/.yarn/changelogs/@furystack-shades-showcase-app.35b36e52.md
@@ -1,0 +1,43 @@
+<!-- version-type: patch -->
+
+# @furystack/shades-showcase-app
+
+## ✨ Features
+
+<!-- PLACEHOLDER: Describe your shiny new features (feat:) -->
+
+## 🐛 Bug Fixes
+
+<!-- PLACEHOLDER: Describe the nasty little bugs that has been eradicated (fix:) -->
+
+## 📚 Documentation
+
+<!-- PLACEHOLDER: Describe documentation changes (docs:) -->
+
+## ⚡ Performance
+
+<!-- PLACEHOLDER: Describe performance improvements (perf:) -->
+
+## ♻️ Refactoring
+
+<!-- PLACEHOLDER: Describe code refactoring (refactor:) -->
+
+## 🧪 Tests
+
+<!-- PLACEHOLDER: Describe test changes (test:) -->
+
+## 📦 Build
+
+<!-- PLACEHOLDER: Describe build system changes (build:) -->
+
+## 👷 CI
+
+<!-- PLACEHOLDER: Describe CI configuration changes (ci:) -->
+
+## ⬆️ Dependencies
+
+- Bumped `@furystack/shades-common-components` to pick up the new `CollectionService` `idField` option for automatic `focusedEntry`/`selection` reconciliation on data changes.
+
+## 🔧 Chores
+
+<!-- PLACEHOLDER: Describe other changes (chore:) -->

--- a/.yarn/changelogs/@furystack-shades-showcase-app.35b36e52.md
+++ b/.yarn/changelogs/@furystack-shades-showcase-app.35b36e52.md
@@ -36,7 +36,7 @@
 
 ## ⬆️ Dependencies
 
-- Bumped `@furystack/shades-common-components` to pick up the new `CollectionService` `idField` option for automatic `focusedEntry`/`selection` reconciliation on data changes.
+- Bump `@furystack/shades-common-components` to pick up the new `CollectionService.idField` option.
 
 ## 🔧 Chores
 

--- a/.yarn/changelogs/furystack.35b36e52.md
+++ b/.yarn/changelogs/furystack.35b36e52.md
@@ -1,0 +1,43 @@
+<!-- version-type: patch -->
+
+# furystack
+
+## ✨ Features
+
+<!-- PLACEHOLDER: Describe your shiny new features (feat:) -->
+
+## 🐛 Bug Fixes
+
+<!-- PLACEHOLDER: Describe the nasty little bugs that has been eradicated (fix:) -->
+
+## 📚 Documentation
+
+<!-- PLACEHOLDER: Describe documentation changes (docs:) -->
+
+## ⚡ Performance
+
+<!-- PLACEHOLDER: Describe performance improvements (perf:) -->
+
+## ♻️ Refactoring
+
+<!-- PLACEHOLDER: Describe code refactoring (refactor:) -->
+
+## 🧪 Tests
+
+<!-- PLACEHOLDER: Describe test changes (test:) -->
+
+## 📦 Build
+
+<!-- PLACEHOLDER: Describe build system changes (build:) -->
+
+## 👷 CI
+
+<!-- PLACEHOLDER: Describe CI configuration changes (ci:) -->
+
+## ⬆️ Dependencies
+
+<!-- PLACEHOLDER: Describe dependency updates (deps:) -->
+
+## 🔧 Chores
+
+- Workspace release accompanying the `@furystack/shades-common-components` `CollectionService` `idField` auto-reconciliation feature; no changes in the root package itself.

--- a/.yarn/versions/35b36e52.yml
+++ b/.yarn/versions/35b36e52.yml
@@ -1,4 +1,4 @@
 releases:
-  "@furystack/shades-common-components": patch
+  "@furystack/shades-common-components": minor
   "@furystack/shades-showcase-app": patch
   furystack: patch

--- a/.yarn/versions/35b36e52.yml
+++ b/.yarn/versions/35b36e52.yml
@@ -1,0 +1,4 @@
+releases:
+  "@furystack/shades-common-components": patch
+  "@furystack/shades-showcase-app": patch
+  furystack: patch

--- a/packages/shades-common-components/src/services/collection-service.spec.ts
+++ b/packages/shades-common-components/src/services/collection-service.spec.ts
@@ -71,6 +71,122 @@ describe('CollectionService', () => {
     })
   })
 
+  describe('idField auto-reconciliation', () => {
+    it('Should reconcile focusedEntry when data changes', () => {
+      const oldEntries = createTestEntries()
+      const newEntries = createTestEntries()
+
+      using(new CollectionService<TestEntry>({ idField: 'foo' }), (service) => {
+        service.data.setValue({ count: 3, entries: oldEntries })
+        service.focusedEntry.setValue(oldEntries[1])
+
+        service.data.setValue({ count: 3, entries: newEntries })
+
+        expect(service.focusedEntry.getValue()).toBe(newEntries[1])
+        expect(service.focusedEntry.getValue()).not.toBe(oldEntries[1])
+      })
+    })
+
+    it('Should reconcile selection when data changes', () => {
+      const oldEntries = createTestEntries()
+      const newEntries = createTestEntries()
+
+      using(new CollectionService<TestEntry>({ idField: 'foo' }), (service) => {
+        service.data.setValue({ count: 3, entries: oldEntries })
+        service.selection.setValue([oldEntries[0], oldEntries[2]])
+
+        service.data.setValue({ count: 3, entries: newEntries })
+
+        const selection = service.selection.getValue()
+        expect(selection[0]).toBe(newEntries[0])
+        expect(selection[1]).toBe(newEntries[2])
+      })
+    })
+
+    it('Should clear focusedEntry if the entry is removed from data', () => {
+      const oldEntries = createTestEntries()
+      const newEntries = [{ ...oldEntries[0] }, { ...oldEntries[2] }]
+
+      using(new CollectionService<TestEntry>({ idField: 'foo' }), (service) => {
+        service.data.setValue({ count: 3, entries: oldEntries })
+        service.focusedEntry.setValue(oldEntries[1])
+
+        service.data.setValue({ count: 2, entries: newEntries })
+
+        expect(service.focusedEntry.getValue()).toBeUndefined()
+      })
+    })
+
+    it('Should remove stale selection entries when data changes', () => {
+      const oldEntries = createTestEntries()
+      const newEntries = [{ ...oldEntries[0] }, { ...oldEntries[2] }]
+
+      using(new CollectionService<TestEntry>({ idField: 'foo' }), (service) => {
+        service.data.setValue({ count: 3, entries: oldEntries })
+        service.selection.setValue([...oldEntries])
+
+        service.data.setValue({ count: 2, entries: newEntries })
+
+        const selection = service.selection.getValue()
+        expect(selection.length).toBe(2)
+        expect(selection[0]).toBe(newEntries[0])
+        expect(selection[1]).toBe(newEntries[1])
+      })
+    })
+
+    it('Should not reconcile when idField is not provided', () => {
+      const oldEntries = createTestEntries()
+      const newEntries = createTestEntries()
+
+      using(new CollectionService<TestEntry>({}), (service) => {
+        service.data.setValue({ count: 3, entries: oldEntries })
+        service.focusedEntry.setValue(oldEntries[1])
+
+        service.data.setValue({ count: 3, entries: newEntries })
+
+        expect(service.focusedEntry.getValue()).toBe(oldEntries[1])
+      })
+    })
+
+    it('Should not update focusedEntry if the reference already matches', () => {
+      const entries = createTestEntries()
+
+      using(new CollectionService<TestEntry>({ idField: 'foo' }), (service) => {
+        service.data.setValue({ count: 3, entries })
+        service.focusedEntry.setValue(entries[0])
+
+        const spy = vi.spyOn(service.focusedEntry, 'setValue')
+
+        service.data.setValue({ count: 3, entries })
+
+        expect(spy).not.toHaveBeenCalled()
+      })
+    })
+
+    it('Should keep selection and keyboard navigation working after data refresh', () => {
+      const oldEntries = createTestEntries()
+      const newEntries = createTestEntries()
+
+      using(new CollectionService<TestEntry>({ idField: 'foo' }), (service) => {
+        service.data.setValue({ count: 3, entries: oldEntries })
+        service.hasFocus.setValue(true)
+        service.focusedEntry.setValue(oldEntries[0])
+
+        service.data.setValue({ count: 3, entries: newEntries })
+
+        service.handleKeyDown(createKeyboardEvent('*'))
+        expect(service.selection.getValue().length).toBe(3)
+
+        service.handleKeyDown(createKeyboardEvent('ArrowDown'))
+        expect(service.focusedEntry.getValue()).toBe(newEntries[1])
+
+        service.handleKeyDown(createKeyboardEvent('Insert'))
+        expect(service.selection.getValue()).not.toContain(newEntries[1])
+        expect(service.focusedEntry.getValue()).toBe(newEntries[2])
+      })
+    })
+  })
+
   describe('handleKeyDown', () => {
     it('Should do nothing when hasFocus is false', () => {
       const testEntries = createTestEntries()

--- a/packages/shades-common-components/src/services/collection-service.spec.ts
+++ b/packages/shades-common-components/src/services/collection-service.spec.ts
@@ -69,6 +69,21 @@ describe('CollectionService', () => {
       expect(hasFocusSpy).toHaveBeenCalled()
       expect(focusedEntrySpy).toHaveBeenCalled()
     })
+
+    it('Should dispose the data subscription when idField is set', () => {
+      const service = new CollectionService<TestEntry>({ idField: 'foo' })
+      const entries = createTestEntries()
+
+      service.data.setValue({ count: 3, entries })
+      service.focusedEntry.setValue(entries[1])
+      expect(service.focusedEntry.getValue()).toBe(entries[1])
+
+      const dataSpy = vi.spyOn(service.data, Symbol.dispose)
+      service[Symbol.dispose]()
+
+      expect(dataSpy).toHaveBeenCalled()
+      expect(() => service.data.setValue({ count: 0, entries: [] })).toThrowError('Observable already disposed')
+    })
   })
 
   describe('idField auto-reconciliation', () => {
@@ -141,10 +156,14 @@ describe('CollectionService', () => {
       using(new CollectionService<TestEntry>({}), (service) => {
         service.data.setValue({ count: 3, entries: oldEntries })
         service.focusedEntry.setValue(oldEntries[1])
+        service.selection.setValue([oldEntries[0], oldEntries[2]])
 
         service.data.setValue({ count: 3, entries: newEntries })
 
         expect(service.focusedEntry.getValue()).toBe(oldEntries[1])
+        const selection = service.selection.getValue()
+        expect(selection[0]).toBe(oldEntries[0])
+        expect(selection[1]).toBe(oldEntries[2])
       })
     })
 

--- a/packages/shades-common-components/src/services/collection-service.ts
+++ b/packages/shades-common-components/src/services/collection-service.ts
@@ -13,11 +13,12 @@ export interface CollectionServiceOptions<T> {
 
   /**
    * A field used as a stable identity key for entries.
-   * When provided, the service automatically reconciles `focusedEntry`
-   * and `selection` after `data` changes so that stale object references
-   * are swapped for their matching counterparts in the new data array.
-   * This keeps keyboard navigation and selection working correctly when
-   * the backing data is rebuilt with new object instances.
+   * When provided, the service automatically reconciles `focusedEntry`,
+   * `selection`, and the internal SHIFT+click focus anchor after `data`
+   * changes so that stale object references are swapped for their matching
+   * counterparts in the new data array. This keeps keyboard navigation and
+   * selection working correctly when the backing data is rebuilt with new
+   * object instances.
    */
   idField?: keyof T
 
@@ -224,6 +225,11 @@ export class CollectionService<T>
       if (reconciled !== currentFocused) {
         this.focusedEntry.setValue(reconciled)
       }
+    }
+
+    if (this.focusAnchor) {
+      const anchor = this.focusAnchor
+      this.focusAnchor = entries.find((e) => e[idField] === anchor[idField])
     }
 
     const currentSelection = this.selection.getValue()

--- a/packages/shades-common-components/src/services/collection-service.ts
+++ b/packages/shades-common-components/src/services/collection-service.ts
@@ -10,6 +10,17 @@ export interface CollectionServiceOptions<T> {
    * An optional field that can be used for quick search
    */
   searchField?: keyof T
+
+  /**
+   * A field used as a stable identity key for entries.
+   * When provided, the service automatically reconciles `focusedEntry`
+   * and `selection` after `data` changes so that stale object references
+   * are swapped for their matching counterparts in the new data array.
+   * This keeps keyboard navigation and selection working correctly when
+   * the backing data is rebuilt with new object instances.
+   */
+  idField?: keyof T
+
   /**
    * @param entry The clicked entry
    * @deprecated Use `subscribe('onRowClick', ...)` instead
@@ -31,7 +42,10 @@ export class CollectionService<T>
   }>
   implements Disposable
 {
+  private dataSubscription?: Disposable
+
   public [Symbol.dispose]() {
+    this.dataSubscription?.[Symbol.dispose]()
     this.data[Symbol.dispose]()
     this.selection[Symbol.dispose]()
     this.searchTerm[Symbol.dispose]()
@@ -200,6 +214,28 @@ export class CollectionService<T>
     this.focusedEntry.setValue(entry)
   }
 
+  private reconcileRefs(entries: T[]): void {
+    const { idField } = this.options
+    if (!idField) return
+
+    const currentFocused = this.focusedEntry.getValue()
+    if (currentFocused) {
+      const reconciled = entries.find((e) => e[idField] === currentFocused[idField])
+      if (reconciled !== currentFocused) {
+        this.focusedEntry.setValue(reconciled)
+      }
+    }
+
+    const currentSelection = this.selection.getValue()
+    if (currentSelection.length > 0) {
+      const entryById = new Map(entries.map((e) => [e[idField], e]))
+      const reconciled = currentSelection.map((s) => entryById.get(s[idField])).filter((e): e is T => e !== undefined)
+      if (reconciled.length !== currentSelection.length || reconciled.some((e, i) => e !== currentSelection[i])) {
+        this.selection.setValue(reconciled)
+      }
+    }
+  }
+
   constructor(private options: CollectionServiceOptions<T> = {}) {
     super()
     if (options.onRowClick) {
@@ -207,6 +243,11 @@ export class CollectionService<T>
     }
     if (options.onRowDoubleClick) {
       this.addListener('onRowDoubleClick', options.onRowDoubleClick)
+    }
+    if (options.idField) {
+      this.dataSubscription = this.data.subscribe(({ entries }) => {
+        this.reconcileRefs(entries)
+      })
     }
   }
 


### PR DESCRIPTION
## 🧭 Overview

Adds an opt‑in `idField` to `CollectionServiceOptions` in `@furystack/shades-common-components`. When provided, `CollectionService` reconciles `focusedEntry` and `selection` against the new entries array on every `data` change, swapping stale object references for their id‑matched counterparts and dropping entries whose id disappeared.

## ✨ What changes

- New `CollectionServiceOptions.idField?: keyof T` option.
- Internal `reconcileRefs(entries)` helper + `data` subscription wired in the constructor when `idField` is set.
- Subscription is disposed in `Symbol.dispose`.
- Behavior is unchanged when `idField` is omitted.

## 🎯 Why

Keyboard navigation and selection silently break when the backing data array is rebuilt with new object instances (e.g. after a refetch), because the held references no longer exist in the new array. Reconciling by id restores the expected UX without requiring callers to re‑apply focus/selection manually.

## 🧪 Tests

7 new unit tests under `idField auto-reconciliation` covering focus/selection reconcile, stale removal, opt‑out, reference‑equality short‑circuit, and end‑to‑end keyboard nav after refresh.
