### PR TITLE
fix(entity-sync-service): Fix current user scope

### DIFF
--- a/.yarn/changelogs/@furystack-entity-sync-service.d2cbe474.md
+++ b/.yarn/changelogs/@furystack-entity-sync-service.d2cbe474.md
@@ -1,0 +1,22 @@
+<!-- version-type: patch -->
+
+# @furystack/entity-sync-service
+
+## 🐛 Bug Fixes
+
+### Stop retaining the per-message websocket injector for the lifetime of a subscription
+
+`SubscriptionManager.subscribeEntity` and `SubscriptionManager.subscribeCollection` previously stored the per-message injector handed in by `SyncSubscribeAction` as the long-lived `clientInjector` for the subscription. With `@furystack/websocket-api@14`, that injector is a per-message scope that gets disposed as soon as the action returns, so every subsequent collection re-evaluation called `findEntities`/`countEntities` on a disposed scope. On any DataSet that exposes `authorizeGet` (or anything else that resolves `IdentityContext`), this turned legitimate change notifications into `subscription-error` messages — visible to clients as snapshot/sidebar/dashboard lists that never refreshed after writes.
+
+The manager now snapshots the caller's identity once at subscribe time (via `IdentityContext.getCurrentUser()`), spawns a fresh long-lived child of the root injector with that identity bound on a snapshot `IdentityContext` (`isAuthenticated`, `isAuthorized` derived from the captured `user.roles`, `getCurrentUser` returning the captured user), and uses that scope for the initial query as well as every subsequent re-evaluation. The captured scope is disposed on `unsubscribe`, on socket close, on `subscription-error` paths, and on manager dispose.
+
+Anonymous callers (no `IdentityContext` bound, or `getCurrentUser()` rejects) fall back to the default unauthenticated `IdentityContext`, so `authorizeGet` hooks still see an unauthenticated identity instead of a system-elevated one.
+
+## 🧪 Tests
+
+- Added regression tests in `subscription-manager.spec.ts` covering the per-message scope disposal scenario:
+  - Collection notifications keep flowing after the caller scope is disposed.
+  - `authorizeGet` re-runs against the captured identity, not the disposed caller scope.
+  - Unauthenticated callers receive `subscription-error` from `authorizeGet` (no identity leakage).
+  - Captured `user.roles` are preserved across re-evaluations.
+  - Entity-update notifications still flow when the caller scope is disposed.

--- a/.yarn/changelogs/furystack.d2cbe474.md
+++ b/.yarn/changelogs/furystack.d2cbe474.md
@@ -1,0 +1,11 @@
+<!-- version-type: patch -->
+
+# furystack
+
+## 🐛 Bug Fixes
+
+- Fixed entity-sync collection re-evaluations failing with `subscription-error` after the bump to `@furystack/websocket-api@14`: `SubscriptionManager` no longer retains the disposable per-message injector. See `@furystack/entity-sync-service` changelog for details.
+
+## 🧪 Tests
+
+- Added regression coverage in `@furystack/entity-sync-service` for the per-message scope disposal scenario, including a test with a DataSet `authorizeGet` hook that mirrors the production failure mode.

--- a/.yarn/versions/d2cbe474.yml
+++ b/.yarn/versions/d2cbe474.yml
@@ -1,0 +1,3 @@
+releases:
+  "@furystack/entity-sync-service": patch
+  furystack: patch

--- a/packages/entity-sync-service/src/subscription-manager.spec.ts
+++ b/packages/entity-sync-service/src/subscription-manager.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { createInjector, type Injector } from '@furystack/inject'
-import { defineStore, InMemoryStore, type StoreToken } from '@furystack/core'
+import { defineStore, IdentityContext, InMemoryStore, type StoreToken, type User } from '@furystack/core'
 import { defineDataSet, type DataSetToken } from '@furystack/repository'
 import { usingAsync } from '@furystack/utils'
 import type { ServerSyncMessage } from '@furystack/entity-sync'
@@ -855,6 +855,197 @@ describe('SubscriptionManager', () => {
 
       expect(manager.activeSubscriptionCount).toBe(0)
       expect(manager.getModelRegistration('TestEntity')).toBeUndefined()
+    })
+  })
+
+  describe('per-message scope disposal regression', () => {
+    /**
+     * Regression for the websocket-api@14 / entity-sync-service interaction:
+     * the per-message scope passed to subscribe* is disposed by the websocket
+     * action runner as soon as the action returns. Subsequent collection
+     * re-evaluations must keep working — the manager must not retain the
+     * disposable scope.
+     */
+    it('should keep collection notifications working after the caller scope is disposed', async () => {
+      await usingAsync(setupManager(), async ({ injector, manager, dataSet }) => {
+        manager.registerModel(TestEntityDataSet)
+
+        const socket = createMockSocket()
+        const messageScope = injector.createScope({ owner: 'message' })
+        await manager.subscribeCollection(socket as unknown as WebSocket, messageScope, 'req-1', 'TestEntity')
+        await messageScope[Symbol.asyncDispose]()
+        socket.send.mockClear()
+
+        await addEntity(dataSet, injector, { id: '1', name: 'Alice', category: 'A' })
+        await new Promise((r) => setTimeout(r, 50))
+
+        const messages = getSentMessages(socket)
+        const snapshotMsg = messages.find((m) => m.type === 'collection-snapshot')
+        expect(snapshotMsg).toBeDefined()
+        const errorMsg = messages.find((m) => m.type === 'subscription-error')
+        expect(errorMsg).toBeUndefined()
+        if (snapshotMsg?.type === 'collection-snapshot') {
+          expect(snapshotMsg.data).toMatchObject([{ id: '1', name: 'Alice', category: 'A' }])
+        }
+      })
+    })
+
+    it('should re-run authorizeGet against the captured identity, not the disposed caller scope', async () => {
+      const AuthorizedStore: StoreToken<TestEntity, 'id'> = defineStore({
+        name: 'test/AuthorizedStore',
+        model: TestEntity,
+        primaryKey: 'id',
+        factory: () => new InMemoryStore({ model: TestEntity, primaryKey: 'id' }),
+      })
+
+      const AuthorizedDataSet: DataSetToken<TestEntity, 'id'> = defineDataSet({
+        name: 'test/AuthorizedDataSet',
+        store: AuthorizedStore,
+        settings: {
+          authorizeGet: async ({ injector }) => {
+            const ctx = injector.get(IdentityContext)
+            const authenticated = await ctx.isAuthenticated()
+            return authenticated ? { isAllowed: true } : { isAllowed: false, message: 'unauthenticated' }
+          },
+        },
+      })
+
+      await usingAsync(createInjector(), async (injector) => {
+        const manager = injector.get(SubscriptionManager)
+        const dataSet = injector.get(AuthorizedDataSet)
+        manager.registerModel(AuthorizedDataSet)
+
+        const messageScope = injector.createScope({ owner: 'message' })
+        const user: User = { username: 'alice', roles: ['reader'] }
+        messageScope.bind(IdentityContext, () => ({
+          isAuthenticated: () => Promise.resolve(true),
+          isAuthorized: (...roles: string[]) => Promise.resolve(roles.every((r) => user.roles.includes(r))),
+          getCurrentUser: <TUser extends User>() => Promise.resolve(user as unknown as TUser),
+        }))
+
+        const socket = createMockSocket()
+        await manager.subscribeCollection(socket as unknown as WebSocket, messageScope, 'req-1', 'TestEntity')
+
+        await messageScope[Symbol.asyncDispose]()
+        socket.send.mockClear()
+
+        await addEntity(dataSet, injector, { id: '1', name: 'Alice', category: 'A' })
+        await new Promise((r) => setTimeout(r, 50))
+
+        const messages = getSentMessages(socket)
+        expect(messages.find((m) => m.type === 'subscription-error')).toBeUndefined()
+        const snapshotMsg = messages.find((m) => m.type === 'collection-snapshot')
+        expect(snapshotMsg).toBeDefined()
+      })
+    })
+
+    it('should send subscription-error when the caller is unauthenticated and authorizeGet rejects', async () => {
+      const RestrictedStore: StoreToken<TestEntity, 'id'> = defineStore({
+        name: 'test/RestrictedStore',
+        model: TestEntity,
+        primaryKey: 'id',
+        factory: () => new InMemoryStore({ model: TestEntity, primaryKey: 'id' }),
+      })
+
+      const RestrictedDataSet: DataSetToken<TestEntity, 'id'> = defineDataSet({
+        name: 'test/RestrictedDataSet',
+        store: RestrictedStore,
+        settings: {
+          authorizeGet: async ({ injector }) => {
+            const ctx = injector.get(IdentityContext)
+            const authenticated = await ctx.isAuthenticated()
+            return authenticated ? { isAllowed: true } : { isAllowed: false, message: 'unauthenticated' }
+          },
+        },
+      })
+
+      await usingAsync(createInjector(), async (injector) => {
+        const manager = injector.get(SubscriptionManager)
+        manager.registerModel(RestrictedDataSet)
+
+        const socket = createMockSocket()
+        await manager.subscribeCollection(socket as unknown as WebSocket, injector, 'req-1', 'TestEntity')
+
+        const messages = getSentMessages(socket)
+        expect(messages).toHaveLength(1)
+        expect(messages[0]).toMatchObject({
+          type: 'subscription-error',
+          requestId: 'req-1',
+        })
+        if (messages[0].type === 'subscription-error') {
+          expect(messages[0].error).toMatch(/unauthenticated/i)
+        }
+        expect(manager.activeSubscriptionCount).toBe(0)
+      })
+    })
+
+    it('should preserve captured user roles for subsequent authorizeGet evaluations', async () => {
+      const RoleAwareStore: StoreToken<TestEntity, 'id'> = defineStore({
+        name: 'test/RoleAwareStore',
+        model: TestEntity,
+        primaryKey: 'id',
+        factory: () => new InMemoryStore({ model: TestEntity, primaryKey: 'id' }),
+      })
+
+      const seenRoles: string[][] = []
+
+      const RoleAwareDataSet: DataSetToken<TestEntity, 'id'> = defineDataSet({
+        name: 'test/RoleAwareDataSet',
+        store: RoleAwareStore,
+        settings: {
+          authorizeGet: async ({ injector }) => {
+            const ctx = injector.get(IdentityContext)
+            const user = await ctx.getCurrentUser<User>().catch(() => undefined)
+            seenRoles.push(user?.roles ?? [])
+            return { isAllowed: true }
+          },
+        },
+      })
+
+      await usingAsync(createInjector(), async (injector) => {
+        const manager = injector.get(SubscriptionManager)
+        const dataSet = injector.get(RoleAwareDataSet)
+        manager.registerModel(RoleAwareDataSet)
+
+        const messageScope = injector.createScope({ owner: 'message' })
+        const user: User = { username: 'alice', roles: ['reader', 'writer'] }
+        messageScope.bind(IdentityContext, () => ({
+          isAuthenticated: () => Promise.resolve(true),
+          isAuthorized: (...roles: string[]) => Promise.resolve(roles.every((r) => user.roles.includes(r))),
+          getCurrentUser: <TUser extends User>() => Promise.resolve(user as unknown as TUser),
+        }))
+
+        const socket = createMockSocket()
+        await manager.subscribeCollection(socket as unknown as WebSocket, messageScope, 'req-1', 'TestEntity')
+        await messageScope[Symbol.asyncDispose]()
+
+        await addEntity(dataSet, injector, { id: '1', name: 'Alice', category: 'A' })
+        await new Promise((r) => setTimeout(r, 50))
+
+        expect(seenRoles.length).toBeGreaterThanOrEqual(2)
+        for (const roles of seenRoles) {
+          expect(roles).toEqual(['reader', 'writer'])
+        }
+      })
+    })
+
+    it('should keep entity snapshots working when the caller scope is disposed before subscribe completes is awaited', async () => {
+      await usingAsync(setupManager(), async ({ injector, manager, dataSet }) => {
+        manager.registerModel(TestEntityDataSet)
+        await addEntity(dataSet, injector, { id: '1', name: 'Alice', category: 'A' })
+
+        const socket = createMockSocket()
+        const messageScope = injector.createScope({ owner: 'message' })
+        await manager.subscribeEntity(socket as unknown as WebSocket, messageScope, 'req-1', 'TestEntity', '1')
+        await messageScope[Symbol.asyncDispose]()
+        socket.send.mockClear()
+
+        await updateEntity(dataSet, injector, '1', { name: 'Bob' })
+
+        const messages = getSentMessages(socket)
+        expect(messages).toHaveLength(1)
+        expect(messages[0].type).toBe('entity-updated')
+      })
     })
   })
 })

--- a/packages/entity-sync-service/src/subscription-manager.ts
+++ b/packages/entity-sync-service/src/subscription-manager.ts
@@ -1,4 +1,4 @@
-import { useSystemIdentityContext, type FilterType } from '@furystack/core'
+import { IdentityContext, useSystemIdentityContext, type FilterType, type User } from '@furystack/core'
 import { defineService, type Injector, type Token } from '@furystack/inject'
 import { type DataSetToken } from '@furystack/repository'
 import type { SyncChangeEntry, ServerSyncMessage, SyncVersion } from '@furystack/entity-sync'
@@ -157,7 +157,53 @@ class SubscriptionManagerImpl implements SubscriptionManager {
   private readonly pendingEntityMessages = new Map<string, ServerSyncMessage[]>()
   private readonly queryCache = new Map<string, QueryCacheEntry>()
 
-  constructor(private readonly systemInjector: Injector) {}
+  constructor(
+    private readonly systemInjector: Injector,
+    private readonly subscriptionScopeParent: Injector,
+  ) {}
+
+  /**
+   * Captures the current identity from `clientInjector` (the per-message
+   * scope provided by the websocket action) and returns a long-lived child
+   * scope of the root injector with that identity bound on a fresh
+   * {@link IdentityContext}.
+   *
+   * The per-message `clientInjector` is disposed by `useWebSocketApi` as
+   * soon as the action returns, so retaining it for the lifetime of a
+   * subscription would break re-evaluation queries that hit `authorizeGet`
+   * (and any other code that resolves `IdentityContext`). Snapshotting the
+   * user once at subscribe time keeps authorization consistent for the
+   * lifetime of the subscription.
+   */
+  private async captureSubscriptionScope(clientInjector: Injector): Promise<Injector> {
+    let capturedUser: User | undefined
+    try {
+      capturedUser = await clientInjector.get(IdentityContext).getCurrentUser<User>()
+    } catch {
+      capturedUser = undefined
+    }
+
+    const scope = this.subscriptionScopeParent.createScope({ owner: 'EntitySyncSubscription' })
+
+    if (capturedUser) {
+      const user = capturedUser
+      const roles = Array.isArray(user.roles) ? [...user.roles] : []
+      scope.bind(IdentityContext, () => ({
+        isAuthenticated: () => Promise.resolve(true),
+        isAuthorized: (...required: string[]) =>
+          Promise.resolve(required.every((role) => roles.some((r) => r === role))),
+        getCurrentUser: <TUser extends User>() => Promise.resolve(user as unknown as TUser),
+      }))
+    }
+
+    return scope
+  }
+
+  private disposeSubscriptionScope(scope: Injector): void {
+    void scope[Symbol.asyncDispose]().catch(() => {
+      /* swallow: scope disposal failures should not break unsubscribe */
+    })
+  }
 
   public registerModel<T, TPrimaryKey extends keyof T>(
     dataSetToken: DataSetToken<T, TPrimaryKey>,
@@ -499,8 +545,10 @@ class SubscriptionManagerImpl implements SubscriptionManager {
       return
     }
 
+    let subscriptionScope: Injector | undefined
     try {
       const subscriptionId = `sub-${++this.subscriptionCounter}`
+      subscriptionScope = await this.captureSubscriptionScope(clientInjector)
 
       if (lastSeq !== undefined && registration.changelog.length > 0) {
         const oldestEntry = registration.changelog[0]
@@ -513,7 +561,14 @@ class SubscriptionManagerImpl implements SubscriptionManager {
             return entry.id === key
           })
 
-          this.storeEntitySubscription(subscriptionId, socket, clientInjector, modelName, key, registration.currentSeq)
+          this.storeEntitySubscription(
+            subscriptionId,
+            socket,
+            subscriptionScope,
+            modelName,
+            key,
+            registration.currentSeq,
+          )
 
           this.sendMessage(socket, {
             type: 'subscribed',
@@ -528,9 +583,9 @@ class SubscriptionManagerImpl implements SubscriptionManager {
         }
       }
 
-      const entity = await registration.getEntity(clientInjector, key)
+      const entity = await registration.getEntity(subscriptionScope, key)
 
-      this.storeEntitySubscription(subscriptionId, socket, clientInjector, modelName, key, registration.currentSeq)
+      this.storeEntitySubscription(subscriptionId, socket, subscriptionScope, modelName, key, registration.currentSeq)
 
       this.sendMessage(socket, {
         type: 'subscribed',
@@ -542,6 +597,9 @@ class SubscriptionManagerImpl implements SubscriptionManager {
         version: { seq: registration.currentSeq, timestamp: new Date().toISOString() },
       })
     } catch (error) {
+      if (subscriptionScope) {
+        this.disposeSubscriptionScope(subscriptionScope)
+      }
       this.sendMessage(socket, {
         type: 'subscription-error',
         requestId,
@@ -570,17 +628,19 @@ class SubscriptionManagerImpl implements SubscriptionManager {
       return
     }
 
+    let subscriptionScope: Injector | undefined
     try {
       const subscriptionId = `sub-${++this.subscriptionCounter}`
+      subscriptionScope = await this.captureSubscriptionScope(clientInjector)
 
       const [results, totalCount] = await Promise.all([
-        registration.findEntities(clientInjector, {
+        registration.findEntities(subscriptionScope, {
           filter,
           top,
           skip,
           order,
         }),
-        registration.countEntities(clientInjector, filter),
+        registration.countEntities(subscriptionScope, filter),
       ])
 
       const currentEntities = new Map<unknown, unknown>()
@@ -592,7 +652,7 @@ class SubscriptionManagerImpl implements SubscriptionManager {
       const subscription: CollectionSubscription = {
         subscriptionId,
         socket,
-        clientInjector,
+        clientInjector: subscriptionScope,
         modelName,
         type: 'collection',
         filter,
@@ -619,6 +679,9 @@ class SubscriptionManagerImpl implements SubscriptionManager {
         version: { seq: registration.currentSeq, timestamp: new Date().toISOString() },
       })
     } catch (error) {
+      if (subscriptionScope) {
+        this.disposeSubscriptionScope(subscriptionScope)
+      }
       this.sendMessage(socket, {
         type: 'subscription-error',
         requestId,
@@ -661,6 +724,7 @@ class SubscriptionManagerImpl implements SubscriptionManager {
       }
 
       this.cleanupSubscriptionState(subscriptionId)
+      this.disposeSubscriptionScope(sub.clientInjector)
     }
   }
 
@@ -688,8 +752,12 @@ class SubscriptionManagerImpl implements SubscriptionManager {
     const subs = this.socketSubscriptionIds.get(socket)
     if (subs) {
       for (const subId of subs) {
+        const sub = this.subscriptions.get(subId)
         this.subscriptions.delete(subId)
         this.cleanupSubscriptionState(subId)
+        if (sub) {
+          this.disposeSubscriptionScope(sub.clientInjector)
+        }
       }
       this.socketSubscriptionIds.delete(socket)
     }
@@ -735,6 +803,10 @@ class SubscriptionManagerImpl implements SubscriptionManager {
       clearTimeout(timer)
     }
 
+    for (const sub of this.subscriptions.values()) {
+      this.disposeSubscriptionScope(sub.clientInjector)
+    }
+
     this.modelRegistrations.clear()
     this.subscriptions.clear()
     this.socketSubscriptionIds.clear()
@@ -748,16 +820,19 @@ class SubscriptionManagerImpl implements SubscriptionManager {
  * DI token for the singleton {@link SubscriptionManager}.
  *
  * The factory creates a dedicated system-identity child scope that the
- * manager uses to resolve DataSets and subscribe to change events. That
- * scope, and the manager's internal state, are torn down when the owning
- * injector is disposed.
+ * manager uses to resolve DataSets and subscribe to change events, and
+ * also passes the owning injector so per-subscription scopes can be
+ * spawned with the subscriber's captured identity (see
+ * {@link SubscriptionManager.subscribeCollection}). Both scopes, and the
+ * manager's internal state, are torn down when the owning injector is
+ * disposed.
  */
 export const SubscriptionManager: Token<SubscriptionManager, 'singleton'> = defineService({
   name: 'furystack/entity-sync-service/SubscriptionManager',
   lifetime: 'singleton',
   factory: ({ injector, onDispose }): SubscriptionManager => {
     const systemInjector = useSystemIdentityContext({ injector, username: 'SubscriptionManager' })
-    const manager = new SubscriptionManagerImpl(systemInjector)
+    const manager = new SubscriptionManagerImpl(systemInjector, injector)
     onDispose(async () => {
       // eslint-disable-next-line furystack/prefer-using-wrapper -- onDispose is the teardown hook
       manager[Symbol.dispose]()


### PR DESCRIPTION
## 🐛 Fix

`SubscriptionManager` retained the per-message websocket injector handed in by `SyncSubscribeAction` as the long-lived `clientInjector` for the subscription. With `@furystack/websocket-api@14`, that scope is disposed as soon as the action returns, so every subsequent collection re-evaluation called `findEntities` / `countEntities` on a disposed scope. On any DataSet that exposes `authorizeGet` (or anything else that resolves `IdentityContext`), this turned legitimate change notifications into `subscription-error` messages — visible to clients as snapshot/sidebar/dashboard lists that never refreshed after writes.

## 🛠️ Solution

`SubscriptionManager.subscribeEntity` / `subscribeCollection` now snapshot the caller's identity once at subscribe time (`IdentityContext.getCurrentUser()`) and spawn a fresh long-lived child of the root injector with that identity bound on a snapshot `IdentityContext`:

- `isAuthenticated` resolves to `true` for the captured user.
- `isAuthorized(...roles)` checks the captured `user.roles`.
- `getCurrentUser()` returns the captured user.

That captured scope is used for the initial query and every re-evaluation, then disposed on `unsubscribe`, socket close, `subscription-error` paths, and manager dispose. Anonymous callers fall back to the default unauthenticated `IdentityContext`, so `authorizeGet` hooks still see an unauthenticated identity instead of a system-elevated one.

## 🧪 Tests

5 new regression tests under `per-message scope disposal regression` in `subscription-manager.spec.ts`:

- Collection notifications keep flowing after the caller scope is disposed.
- `authorizeGet` re-runs against the captured identity, not the disposed caller scope.
- Unauthenticated callers receive `subscription-error` from `authorizeGet` (no identity leakage).
- Captured `user.roles` are preserved across re-evaluations.
- Entity-update notifications still flow when the caller scope is disposed.

## 📦 Versioning

- `@furystack/entity-sync-service`: patch
- `furystack`: patch
