### PR TITLE
Feat/serializable cache

### DIFF
--- a/.yarn/changelogs/@furystack-auth-google.9a8989a8.md
+++ b/.yarn/changelogs/@furystack-auth-google.9a8989a8.md
@@ -1,0 +1,7 @@
+<!-- version-type: patch -->
+
+# @furystack/auth-google
+
+## ⬆️ Dependencies
+
+- Bumped the transitive `@furystack/cache` dependency (via `@furystack/rest-service`) to its new major version. No source changes were required in this package.

--- a/.yarn/changelogs/@furystack-auth-jwt.9a8989a8.md
+++ b/.yarn/changelogs/@furystack-auth-jwt.9a8989a8.md
@@ -1,0 +1,7 @@
+<!-- version-type: patch -->
+
+# @furystack/auth-jwt
+
+## ⬆️ Dependencies
+
+- Bumped the transitive `@furystack/cache` dependency (via `@furystack/rest-service`) to its new major version. No source changes were required in this package.

--- a/.yarn/changelogs/@furystack-cache.9a8989a8.md
+++ b/.yarn/changelogs/@furystack-cache.9a8989a8.md
@@ -11,10 +11,10 @@ The predicate-based range APIs `Cache.obsoleteRange((value, args) => boolean)` a
 **Migration:** switch to the new tag-based invalidation API. Configure `getTags` on the cache and call `obsoleteByTag(tag)` / `removeByTag(tag)` with a plain string. See the new feature entry below.
 
 ```ts
-// Before
+// ❌ Before
 cache.removeRange((value) => value.username === username)
 
-// After
+// ✅ After
 const cache = new Cache<User, [string], `user:${string}`>({
   load: (sessionId) => resolveSession(sessionId),
   getKey: (sessionId) => `cookie:${sessionId}`,
@@ -23,27 +23,13 @@ const cache = new Cache<User, [string], `user:${string}`>({
 cache.removeByTag(`user:${username}`)
 ```
 
+**Impact:** any caller of `obsoleteRange` / `removeRange` will fail to compile. Tags must be designed up-front (in `getTags`) for every invalidation pattern previously expressed as a predicate.
+
 ## ✨ Features
-
-### `getKey` option for `Cache`
-
-Added a `getKey?: (...args: TArgs) => string` option to `CacheSettings`. When supplied it overrides the default `JSON.stringify(args)` cache-index resolver, so callers can use cache args that include large or non-stringifiable values (e.g. `IncomingMessage`, DOM nodes) and still index entries by a small derived key.
-
-**Example:**
-
-```typescript
-const cache = new Cache<User, [string, IncomingMessage]>({
-  load: (_sessionId, request) => walkProviders(request),
-  getKey: (sessionId) => sessionId, // request is excluded from the key
-  cacheTimeMs: 30_000,
-})
-
-const user = await cache.get('session-abc', request)
-```
 
 ### Tag-based invalidation (`getTags`, `obsoleteByTag`, `removeByTag`)
 
-`Cache` now supports tag-based invalidation. The new `getTags?: (value, ...args) => readonly TTag[]` setting attaches a set of plain string tags to each entry whenever it transitions to a `'loaded'` state. The new `obsoleteByTag(tag)` and `removeByTag(tag)` methods then act on every entry currently bound to that tag, returning the affected entry count.
+`Cache` now supports tag-based invalidation. The new `getTags?: (value, ...args) => readonly TTag[]` setting attaches a set of plain string tags to each entry whenever it transitions to a `'loaded'` state (via successful `load` / `reload` or `setExplicitValue` with a loaded value). The new `obsoleteByTag(tag)` and `removeByTag(tag)` methods then act on every entry currently bound to that tag, returning the affected entry count.
 
 Tags are deliberately serializable so the same invalidation can be replicated by other processes — designed for replay over a cross-node event bus. `getTags` receives both the loaded value and the originating args, so tags can incorporate state that lives only on the value side (e.g. extracting a `username` from a session-keyed identity cache). The third generic parameter `TTag extends string = string` lets callers narrow tags to a string-literal union for compile-time safety.
 
@@ -65,10 +51,12 @@ cache.removeByTag('tenant:acme') // drops every entry for a tenant
 cache.obsoleteByTag('typo:foo') // ❌ TypeScript error
 ```
 
-Tags are deduplicated, persist across `loading` / `failed` / `obsolete` transitions until the next successful load recomputes them, and are cleared automatically on LRU eviction, `remove`, and `flushAll`.
+Tags are deduplicated, persist across `loading` / `failed` / `obsolete` transitions until the next successful load recomputes them, and are cleared automatically on LRU eviction, `remove`, and `flushAll`. `removeByTag` also clears the per-key stale / cache TTL timers owned by the `Cache` wrapper.
 
-## 🐛 Bug Fixes
+## 🧪 Tests
 
-### `setExplicitValue` now arms TTL timers for loaded values
+- Added coverage for tag indexing, deduplication, eviction, and `setExplicitValue` interactions with the new tag pipeline in `cache.spec.ts`.
 
-`setExplicitValue` previously stored the value but never set up the configured `staleTimeMs` / `cacheTimeMs` timers, so explicitly-primed entries lived forever regardless of the cache configuration. It now calls the same `setupTimers` path that a normal `load()` does whenever the supplied value's status is `'loaded'`. Non-loaded values (`loading`, `failed`, `obsolete`) still leave timers untouched, matching prior behavior.
+## 📚 Documentation
+
+- Documented the tag-based invalidation API in `packages/cache/README.md` (replaces the prior `removeRange` example).

--- a/.yarn/changelogs/@furystack-cache.ce3bbdb1.md
+++ b/.yarn/changelogs/@furystack-cache.ce3bbdb1.md
@@ -1,0 +1,33 @@
+<!-- version-type: minor -->
+
+# @furystack/cache
+
+## ✨ Features
+
+### `getKey` option for `Cache`
+
+Added a `getKey?: (...args: TArgs) => string` option to `CacheSettings`. When supplied it overrides the default `JSON.stringify(args)` cache-index resolver, so callers can use cache args that include large or non-stringifiable values (e.g. `IncomingMessage`, DOM nodes) and still index entries by a small derived key.
+
+**Example:**
+
+```typescript
+const cache = new Cache<User, [string, IncomingMessage]>({
+  load: (_sessionId, request) => walkProviders(request),
+  getKey: (sessionId) => sessionId, // request is excluded from the key
+  cacheTimeMs: 30_000,
+})
+
+const user = await cache.get('session-abc', request)
+```
+
+**Note:** the predicates passed to `Cache.obsoleteRange` and `Cache.removeRange` receive the args reference from the most recent `get` / `reload` / `setExplicitValue` call for that entry. Do not mutate args after caching; clone before passing if a snapshot is needed.
+
+## 🐛 Bug Fixes
+
+### `setExplicitValue` now arms TTL timers for loaded values
+
+`setExplicitValue` previously stored the value but never set up the configured `staleTimeMs` / `cacheTimeMs` timers, so explicitly-primed entries lived forever regardless of the cache configuration. It now calls the same `setupTimers` path that a normal `load()` does whenever the supplied value's status is `'loaded'`. Non-loaded values (`loading`, `failed`, `obsolete`) still leave timers untouched, matching prior behavior.
+
+### `obsoleteRange` / `removeRange` now work with custom `getKey`
+
+The range APIs previously rebuilt the predicate's `args` argument by calling `JSON.parse(key)`, which threw or returned garbage whenever a custom `getKey` produced non-JSON keys. The state manager now stores the args alongside each entry (refreshed on every `get` / `reload` / `setExplicitValue`) so range predicates receive the live args reference regardless of how the cache key is computed.

--- a/.yarn/changelogs/@furystack-cache.ce3bbdb1.md
+++ b/.yarn/changelogs/@furystack-cache.ce3bbdb1.md
@@ -1,6 +1,27 @@
-<!-- version-type: minor -->
+<!-- version-type: major -->
 
 # @furystack/cache
+
+## 💥 Breaking Changes
+
+### Removed `Cache.obsoleteRange` and `Cache.removeRange`
+
+The predicate-based range APIs `Cache.obsoleteRange((value, args) => boolean)` and `Cache.removeRange((value, args) => boolean)` have been removed. Their predicate signature was inherently non-serializable, which made it impossible to replicate the same invalidation across processes (e.g. over a cross-node event bus).
+
+**Migration:** switch to the new tag-based invalidation API. Configure `getTags` on the cache and call `obsoleteByTag(tag)` / `removeByTag(tag)` with a plain string. See the new feature entry below.
+
+```ts
+// Before
+cache.removeRange((value) => value.username === username)
+
+// After
+const cache = new Cache<User, [string], `user:${string}`>({
+  load: (sessionId) => resolveSession(sessionId),
+  getKey: (sessionId) => `cookie:${sessionId}`,
+  getTags: (user) => [`user:${user.username}`],
+})
+cache.removeByTag(`user:${username}`)
+```
 
 ## ✨ Features
 
@@ -20,14 +41,34 @@ const cache = new Cache<User, [string, IncomingMessage]>({
 const user = await cache.get('session-abc', request)
 ```
 
-**Note:** the predicates passed to `Cache.obsoleteRange` and `Cache.removeRange` receive the args reference from the most recent `get` / `reload` / `setExplicitValue` call for that entry. Do not mutate args after caching; clone before passing if a snapshot is needed.
+### Tag-based invalidation (`getTags`, `obsoleteByTag`, `removeByTag`)
+
+`Cache` now supports tag-based invalidation. The new `getTags?: (value, ...args) => readonly TTag[]` setting attaches a set of plain string tags to each entry whenever it transitions to a `'loaded'` state. The new `obsoleteByTag(tag)` and `removeByTag(tag)` methods then act on every entry currently bound to that tag, returning the affected entry count.
+
+Tags are deliberately serializable so the same invalidation can be replicated by other processes — designed for replay over a cross-node event bus. `getTags` receives both the loaded value and the originating args, so tags can incorporate state that lives only on the value side (e.g. extracting a `username` from a session-keyed identity cache). The third generic parameter `TTag extends string = string` lets callers narrow tags to a string-literal union for compile-time safety.
+
+**Example:**
+
+```typescript
+type UserCacheTag = `tenant:${string}` | `user:${string}`
+
+const cache = new Cache<User, [string], UserCacheTag>({
+  load: (sessionId) => resolveSession(sessionId),
+  getKey: (sessionId) => `cookie:${sessionId}`,
+  getTags: (user) => [`tenant:${user.tenant}`, `user:${user.username}`],
+})
+
+await cache.get('session-abc')
+
+cache.obsoleteByTag('user:alice') // marks loaded entries stale
+cache.removeByTag('tenant:acme') // drops every entry for a tenant
+cache.obsoleteByTag('typo:foo') // ❌ TypeScript error
+```
+
+Tags are deduplicated, persist across `loading` / `failed` / `obsolete` transitions until the next successful load recomputes them, and are cleared automatically on LRU eviction, `remove`, and `flushAll`.
 
 ## 🐛 Bug Fixes
 
 ### `setExplicitValue` now arms TTL timers for loaded values
 
 `setExplicitValue` previously stored the value but never set up the configured `staleTimeMs` / `cacheTimeMs` timers, so explicitly-primed entries lived forever regardless of the cache configuration. It now calls the same `setupTimers` path that a normal `load()` does whenever the supplied value's status is `'loaded'`. Non-loaded values (`loading`, `failed`, `obsolete`) still leave timers untouched, matching prior behavior.
-
-### `obsoleteRange` / `removeRange` now work with custom `getKey`
-
-The range APIs previously rebuilt the predicate's `args` argument by calling `JSON.parse(key)`, which threw or returned garbage whenever a custom `getKey` produced non-JSON keys. The state manager now stores the args alongside each entry (refreshed on every `get` / `reload` / `setExplicitValue`) so range predicates receive the live args reference regardless of how the cache key is computed.

--- a/.yarn/changelogs/@furystack-entity-sync-service.9a8989a8.md
+++ b/.yarn/changelogs/@furystack-entity-sync-service.9a8989a8.md
@@ -1,0 +1,7 @@
+<!-- version-type: patch -->
+
+# @furystack/entity-sync-service
+
+## ⬆️ Dependencies
+
+- Bumped the transitive `@furystack/cache` dependency (via `@furystack/rest-service`) to its new major version. No source changes were required in this package.

--- a/.yarn/changelogs/@furystack-rest-service.9a8989a8.md
+++ b/.yarn/changelogs/@furystack-rest-service.9a8989a8.md
@@ -1,0 +1,7 @@
+<!-- version-type: patch -->
+
+# @furystack/rest-service
+
+## ⬆️ Dependencies
+
+- Bumped `@furystack/cache` to its new major version. The removed `obsoleteRange` / `removeRange` APIs are not used by `@furystack/rest-service`, so no source changes were required. See the `@furystack/cache` changelog for the migration if you import the cache directly alongside this package.

--- a/.yarn/changelogs/@furystack-shades-common-components.9a8989a8.md
+++ b/.yarn/changelogs/@furystack-shades-common-components.9a8989a8.md
@@ -1,0 +1,7 @@
+<!-- version-type: patch -->
+
+# @furystack/shades-common-components
+
+## ⬆️ Dependencies
+
+- Bumped `@furystack/cache` to its new major version. No call sites in this package used the removed `obsoleteRange` / `removeRange` APIs, so no source changes were required. See the `@furystack/cache` changelog for the migration if you import the cache directly alongside this package.

--- a/.yarn/changelogs/@furystack-shades-showcase-app.9a8989a8.md
+++ b/.yarn/changelogs/@furystack-shades-showcase-app.9a8989a8.md
@@ -1,0 +1,7 @@
+<!-- version-type: patch -->
+
+# @furystack/shades-showcase-app
+
+## ⬆️ Dependencies
+
+- Bumped `@furystack/cache` to its new major version. No call sites in this package used the removed `obsoleteRange` / `removeRange` APIs, so no source changes were required. See the `@furystack/cache` changelog for the migration if you import the cache directly alongside this package.

--- a/.yarn/changelogs/@furystack-websocket-api.9a8989a8.md
+++ b/.yarn/changelogs/@furystack-websocket-api.9a8989a8.md
@@ -1,0 +1,7 @@
+<!-- version-type: patch -->
+
+# @furystack/websocket-api
+
+## ⬆️ Dependencies
+
+- Bumped the transitive `@furystack/cache` dependency (via `@furystack/rest-service`) to its new major version. No source changes were required in this package.

--- a/.yarn/changelogs/furystack.9a8989a8.md
+++ b/.yarn/changelogs/furystack.9a8989a8.md
@@ -1,0 +1,7 @@
+<!-- version-type: patch -->
+
+# furystack
+
+## ⬆️ Dependencies
+
+- Released alongside the new major of `@furystack/cache`. See the `@furystack/cache` changelog for the breaking change (removal of `obsoleteRange` / `removeRange`) and the new tag-based invalidation API (`getTags`, `obsoleteByTag`, `removeByTag`).

--- a/.yarn/versions/9a8989a8.yml
+++ b/.yarn/versions/9a8989a8.yml
@@ -1,0 +1,10 @@
+releases:
+  "@furystack/auth-google": patch
+  "@furystack/auth-jwt": patch
+  "@furystack/cache": major
+  "@furystack/entity-sync-service": patch
+  "@furystack/rest-service": patch
+  "@furystack/shades-common-components": patch
+  "@furystack/shades-showcase-app": patch
+  "@furystack/websocket-api": patch
+  furystack: patch

--- a/docs/internal/cross-node-bus-spike.md
+++ b/docs/internal/cross-node-bus-spike.md
@@ -58,9 +58,10 @@ without quietly losing correctness on every channel listed above.
   application can share.
 - Ship a usable in-process default and a production-grade Redis Streams
   adapter alongside it.
-- Replace the in-process `EventHub` paths in entity-sync and identity
-  flows with bus-backed facades, **without breaking existing app code**
-  that uses the local `HttpUserContext` events directly.
+- Augment the in-process `EventHub` paths in entity-sync and identity
+  flows with bus-backed facades that ride **alongside** the local
+  emits, **without breaking existing app code** that uses the local
+  `HttpUserContext` events directly.
 - Make app-defined facades a first-class extension point: app authors
   build typed wrappers over the bus the same way framework facades do.
 - Enforce capability requirements at registration time so misconfigured
@@ -77,7 +78,7 @@ without quietly losing correctness on every channel listed above.
 
 ## 4. Success metrics
 
-The v1 release is "done" when all three numbers hold in the smoke test
+The v1 release is "done" when all four numbers hold in the smoke test
 harness described in §13:
 
 | Metric                                                         | Target                             |
@@ -252,8 +253,9 @@ export interface CrossNodeBus extends Disposable {
 
   /**
    * Replay messages on `topic` from `fromSeq` (exclusive) up to the most
-   * recent. Throws if `bus.capabilities.replay` is `false`. May reject
-   * with a `ReplayWindowExceededError` if `fromSeq` is older than the
+   * recent. Throws synchronously if `bus.capabilities.replay` is
+   * `false`. Throws (or yields an error on first iteration)
+   * `ReplayWindowExceededError` if `fromSeq` is older than the
    * adapter's retained window — facades fall back to a full snapshot.
    */
   replay(topic: string, fromSeq: string): AsyncIterable<BusMessage>
@@ -299,7 +301,7 @@ Design choices:
 
 ```ts
 export const CrossNodeBus = defineService({
-  name: '@furystack/cross-node-bus',
+  name: 'furystack/cross-node-bus/CrossNodeBus',
   lifetime: 'singleton',
   factory: () => new InProcessCrossNodeBus(),
 })
@@ -374,8 +376,8 @@ throw a clear error at registration time.
 | In-process    | 1 000 messages / topic (ring buffer) | constructor `{ replayWindow }` |
 | Redis Streams | `MAXLEN ~ 10000` per stream          | constructor `{ replayWindow }` |
 
-Out-of-window replay rejects with `ReplayWindowExceededError`; facades
-fall back to a full snapshot path.
+Out-of-window replay throws (or yields on first iteration)
+`ReplayWindowExceededError`; facades fall back to a full snapshot path.
 
 ## 9. Capability matrix & enforcement
 
@@ -414,6 +416,31 @@ export type IdentityEvent =
   | { type: 'passwordChanged'; username: string }
 ```
 
+#### Facade interface
+
+```ts
+export interface IdentityEventBus extends Disposable {
+  /** Publishes a typed identity event on the underlying bus. */
+  publish(event: IdentityEvent): Promise<void>
+
+  /**
+   * Subscribes to a single event type. The handler receives the event
+   * payload narrowed to the requested type. Returns a `Disposable`
+   * that removes the listener on dispose.
+   */
+  subscribe<TType extends IdentityEvent['type']>(
+    type: TType,
+    handler: (event: Extract<IdentityEvent, { type: TType }>) => void,
+  ): Disposable
+}
+```
+
+The shape mirrors `EventHub<T>.subscribe` so consumers familiar with
+`httpUserContext.subscribe('onLogout', …)` need no relearning. The
+facade implementation composes an internal `EventHub` for typed
+local dispatch and bridges it to `CrossNodeBus.publish` /
+`CrossNodeBus.subscribe` under a fixed `identity/` topic prefix.
+
 #### Wiring (publish side)
 
 `HttpUserContext.cookieLogout` keeps its existing local emit, **and**
@@ -425,12 +452,17 @@ public async cookieLogout(request, response): Promise<void> {
   // … existing cookie clearing + session-store removal …
 
   if (sessionId) {
-    this.userCache.invalidate(`cookie:${sessionId}`)
+    this.userCache.invalidate(sessionCacheKey(sessionId))
     void this.identityEventBus.publish({ type: 'userLoggedOut', sessionId })
   }
   this.emit('onLogout', undefined)
 }
 ```
+
+`sessionCacheKey(sessionId)` is the shared helper introduced in M0.2 —
+producer (`cookie-auth-provider.getCacheKey`), local invalidation
+(`HttpUserContext.cookieLogout`), and bus subscribers all derive the
+same string from one source of truth.
 
 The local `EventHub` emit is preserved — apps that already subscribe
 to `httpUserContext` events keep working unchanged. Cross-node
@@ -440,11 +472,11 @@ fan-out is purely additive.
 
 ```ts
 identityEventBus.subscribe('userLoggedOut', ({ sessionId }) => {
-  userCache.invalidate(`cookie:${sessionId}`)
+  userCache.invalidate(sessionCacheKey(sessionId))
 })
 
 identityEventBus.subscribe('sessionInvalidated', ({ sessionId }) => {
-  userCache.invalidate(`cookie:${sessionId}`)
+  userCache.invalidate(sessionCacheKey(sessionId))
 })
 
 identityEventBus.subscribe('userRolesChanged', ({ username }) => {
@@ -648,7 +680,7 @@ Every publish/subscribe path emits structured events to
 
 - `onCrossNodePublished` — `{ topic, originId, byteLength }`
 - `onCrossNodeReceived` — `{ topic, originId, lagMs }`
-- `onCrossNodeError` — `{ topic, error, phase: 'publish' | 'subscribe' | 'serialize' }`
+- `onCrossNodeError` — `{ topic, error, phase: 'publish' | 'subscribe' | 'subscribeForeign' | 'replay' | 'serialize' }`
 
 `lagMs = Date.now() - Date.parse(message.emittedAt)` and is emitted on
 **every received message** — the cost is sub-microsecond and the
@@ -703,11 +735,13 @@ cleanly. M0.3 + M0.4 are recommended but optional — skipping them
 turns Milestone 3 into a chunkier diff but does not change the end
 state.
 
-- [ ] **M0.1 — Wire `getTags` into `UserResolutionCache`.** Add
-      `getTags: (user) => [\`user:${user.username}\`]` to the
-      internal `Cache` constructor. Expose `invalidateByUser(username)`
-      on the `UserResolutionCache` interface, backed by
-      `cache.removeByTag(\`user:${username}\`)`. Useful in single-node
+- [ ] **M0.1 — Wire `getTags` into `UserResolutionCache`.** Widen the
+      internal `Cache` generic from `Cache<User, [string]>` to
+      `Cache<User, [string], \`user:${string}\`>` for typed-tag safety
+      and add `getTags: (user) => [\`user:${user.username}\`]`to
+    the constructor. Expose`invalidateByUser(username)`on the
+   `UserResolutionCache`interface, backed by
+   `cache.removeByTag(\`user:${username}\`)`. Useful in single-node
     deployments today (apps currently have no per-user
     invalidation short of `invalidateAll`) and is the hook
     `IdentityEventBus` consumes in Milestone 2.

--- a/docs/internal/cross-node-bus-spike.md
+++ b/docs/internal/cross-node-bus-spike.md
@@ -694,6 +694,43 @@ re-exports. The implementer must check exports and bump accordingly.
 Numbered ordering implies prerequisites. Each milestone is mergeable
 and releasable on its own.
 
+### Milestone 0 — Pre-work (independent of bus)
+
+These items land as standalone PRs **before** any bus code. Each is
+independently valuable on `main` today and unblocks downstream
+milestones. M0.1 + M0.2 are required to make Milestone 2 merge
+cleanly. M0.3 + M0.4 are recommended but optional — skipping them
+turns Milestone 3 into a chunkier diff but does not change the end
+state.
+
+- [ ] **M0.1 — Wire `getTags` into `UserResolutionCache`.** Add
+      `getTags: (user) => [\`user:${user.username}\`]` to the
+      internal `Cache` constructor. Expose `invalidateByUser(username)`
+      on the `UserResolutionCache` interface, backed by
+      `cache.removeByTag(\`user:${username}\`)`. Useful in single-node
+    deployments today (apps currently have no per-user
+    invalidation short of `invalidateAll`) and is the hook
+    `IdentityEventBus` consumes in Milestone 2.
+- [ ] **M0.2 — Centralize identity cache-key / tag shape.** Extract
+      the `cookie:${sessionId}` cache-key template and the
+      `user:${username}` tag template into a small shared helpers
+      module consumed by `cookie-auth-provider.getCacheKey`,
+      `HttpUserContext.cookieLogout`, `UserResolutionCache`, and
+      (later) `IdentityEventBus` subscribers. Prevents drift between
+      local invalidation and bus-replicated invalidation.
+- [ ] **M0.3 — Extract `SequenceGenerator` from `SubscriptionManager`.**
+      Wrap the `incrementVersion` / `currentSeq++` logic behind an
+      internal interface with `next(modelName): SyncVersion`. Default
+      impl is the current per-registration counter. Turns Milestone 3's
+      swap to bus-assigned sequence into a factory swap rather than
+      scattered edits.
+- [ ] **M0.4 — Extract `ChangeLog` from `SubscriptionManager`.** Wrap
+      the `changelog` / `changelogRetentionMs` / `pruneChangelog`
+      triple behind an interface (`append(entry)`,
+      `since(fromSeq): AsyncIterable<entry>`). Default impl is the
+      existing in-process ring + retention prune. Same swap pattern:
+      Milestone 3 plugs in a `bus.replay`-backed impl.
+
 ### Milestone 1 — Bus core & in-process adapter
 
 - [ ] Create `@furystack/cross-node-bus` package with the
@@ -711,10 +748,11 @@ and releasable on its own.
 
 - [ ] Define event union + token + factory.
 - [ ] Wire `HttpUserContext.cookieLogout` to publish.
-- [ ] Subscribe in the factory; on `userLoggedOut` /
+- [ ] Subscribe in the factory: on `userLoggedOut` /
       `sessionInvalidated` invalidate the local
-      `UserResolutionCache` entry.
-- [ ] Add `invalidateByUser(username)` to `UserResolutionCache`.
+      `UserResolutionCache` entry; on `userRolesChanged` /
+      `userDeleted` / `passwordChanged` call `invalidateByUser`
+      (added in M0.1).
 - [ ] Multi-node integration test (≥ 2 in-process bus instances)
       proving cross-node identity invalidation.
 - [ ] (Stretch) on `userLoggedOut`, walk the
@@ -727,8 +765,12 @@ and releasable on its own.
       `CrossNodeBus`).
 - [ ] Refactor `SubscriptionManager.registerModel` to publish +
       subscribe via the broadcaster; single fan-out path.
-- [ ] Move sequence-number generation into the broadcaster;
-      in-process bus keeps a local counter.
+- [ ] Swap the M0.3 `SequenceGenerator` factory to a bus-assigned
+      impl; in-process bus keeps a local counter. (If M0.3 was
+      skipped, this expands to inlined edits across `SubscriptionManager`.)
+- [ ] Swap the M0.4 `ChangeLog` factory to a `bus.replay`-backed
+      impl. (If M0.4 was skipped, this expands to dropping
+      `changelog` / `pruneChangelog` and rewriting reconnection paths.)
 - [ ] Server-side seq dedup with TTL eviction.
 - [ ] Verify all existing tests pass — single-node story unchanged.
 - [ ] Multi-node integration test (≥ 2 in-process bus instances)
@@ -837,6 +879,13 @@ development; none of them gate the v1 plan.
   `@furystack/rest-service`. Bounds cross-instance staleness for
   session/role changes; this PRD collapses that window further for
   the events where sub-TTL latency matters.
+- **`@furystack/cache` tag-based invalidation (landed)** — the major
+  release that removed the predicate-based `obsoleteRange` /
+  `removeRange` in favor of `getTags` / `obsoleteByTag` /
+  `removeByTag`. Tags are deliberately serializable so the same
+  invalidation can be replayed over the bus. This is the prerequisite
+  the M0.1 `UserResolutionCache.invalidateByUser` and the §10.1
+  `IdentityEventBus` subscribers consume.
 - **`docs/internal/functional-di-migration-plan.md`** — established
   the "interface + token + factory" pattern this PRD follows for
   the `CrossNodeBus` token, every facade, and every adapter

--- a/docs/internal/cross-node-bus-spike.md
+++ b/docs/internal/cross-node-bus-spike.md
@@ -1,196 +1,262 @@
-# Spike: `@furystack/cross-node-bus` — shared cross-process event bus
+# PRD: `@furystack/cross-node-bus` — shared cross-process event bus
 
-## Goal
+> **Status:** Draft v1 · supersedes the original spike (kept in git history).
+> **Owner:** FuryStack core team.
+> **Target release:** initial public packages alongside next minor cycle of
+> `@furystack/rest-service` and `@furystack/entity-sync-service`.
 
-Provide a single, transport-agnostic publish/subscribe primitive that
-multiple FuryStack subsystems (and applications) can use to keep state
-consistent across processes behind a load balancer. Specialized
-"facades" — `ChangeBroadcaster` for entity-sync,
-`IdentityEventBroadcaster` for auth, app-defined facades for custom
-events — sit on top of the shared bus and reuse the same transport
-configuration.
+## 1. Glossary
 
-## Motivation — multi-node hazards inventory
+| Term                 | Meaning                                                                                            |
+| -------------------- | -------------------------------------------------------------------------------------------------- |
+| **Bus**              | The `CrossNodeBus` abstraction defined by this PRD. Pub/sub primitive.                             |
+| **Adapter**          | Concrete transport implementation of `CrossNodeBus` (in-process, Redis Streams, …).                |
+| **Broker**           | The external service an adapter talks to (Redis instance, NATS server, Kafka cluster).             |
+| **Facade**           | Typed, opinionated wrapper consuming the bus (`IdentityEventBus`, `EntityChangeBus`, app-defined). |
+| **Topic**            | String channel identifier on the bus. Adapters may prefix it on the wire.                          |
+| **Node**             | A single process instance of a service. Owns one `CrossNodeBus` instance.                          |
+| **`nodeId`**         | Stable, process-unique id of a node. Stamped on every published message.                           |
+| **Service**          | A logically-named deployment unit; usually scaled to multiple nodes.                               |
+| **`originId`**       | The `nodeId` of the publisher; included in every received message.                                 |
+| **Sequence (`seq`)** | Adapter-assigned monotonic per-topic id used for replay and dedup.                                 |
+| **Replay window**    | Bounded retention of past messages an adapter can re-deliver to a reconnecting consumer.           |
 
-Today every cross-cutting in-memory channel in the framework is
-process-local. None of these propagate to sibling instances:
+## 2. Problem & motivation
 
-| Subsystem   | Channel                                                                        | Today's behavior      | Multi-node failure                                                   |
-| ----------- | ------------------------------------------------------------------------------ | --------------------- | -------------------------------------------------------------------- |
-| Entity sync | `DataSet.emit('onEntityAdded' \| 'onEntityUpdated' \| 'onEntityRemoved', ...)` | In-process `EventHub` | Write on node A → subscribers on node B never see it.                |
-| Auth        | `HttpUserContext.emit('onLogin' \| 'onLogout' \| 'onSessionInvalidated', ...)` | In-process `EventHub` | Logout on node A → cookie cache on node B stays populated until TTL. |
-| Auth        | `UserResolutionCache.invalidate(...)`                                          | In-process Map        | Manual invalidation on one node has no effect on siblings.           |
-| Custom      | App-defined `EventHub`s, `ObservableValue`s                                    | In-process            | Anything subscribed for cross-node coordination silently no-ops.     |
+FuryStack apps deploy as one or more services, each scaled to multiple nodes
+behind a load balancer. Today every cross-cutting in-memory channel in the
+framework is process-local: writes, logouts, cache invalidations, and
+app-defined coordination events stay on the node that produced them.
+Sibling nodes silently diverge until something else (TTL expiry, restart,
+client reconnect) re-syncs them.
+
+The user-visible consequences span identity, entity sync, and any custom
+coordination an app builds with `EventHub` or `ObservableValue`:
+
+| Subsystem   | Channel                                                                      | Today's behavior      | Multi-node failure                                                 |
+| ----------- | ---------------------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------ |
+| Entity sync | `DataSet.emit('onEntityAdded' \| 'onEntityUpdated' \| 'onEntityRemoved', …)` | In-process `EventHub` | Write on node A → subscribers on node B never see it.              |
+| Auth        | `HttpUserContext.emit('onLogin' \| 'onLogout' \| 'onSessionInvalidated', …)` | In-process `EventHub` | Logout on node A → cookie cache on node B stays populated for TTL. |
+| Auth        | `UserResolutionCache.invalidate(…)`                                          | In-process `Map`      | Manual invalidation on one node has no effect on siblings.         |
+| Custom      | App-defined `EventHub`s, `ObservableValue`s                                  | In-process            | Anything subscribed for cross-node coordination silently no-ops.   |
 
 The
-[`@furystack/rest-service` short-TTL user-resolution cache](../../packages/rest-service/src/user-resolution-cache.ts) bounds
-identity staleness to the configured TTL window. A cross-node bus
-collapses that window from "TTL" (default 30 s) to "bus latency"
-(single-digit ms with Redis pub/sub) for the cases where it matters.
+[`@furystack/rest-service` short-TTL user-resolution cache](../../packages/rest-service/src/user-resolution-cache.ts)
+bounds identity staleness to its TTL window. A cross-node bus collapses
+that window from "TTL" (default 30 s) to "bus latency" (single-digit ms
+with Redis pub/sub) for the cases where it matters.
 
-## Constraints
+Without a shared bus, a FuryStack app cannot be horizontally scaled
+without quietly losing correctness on every channel listed above.
 
-Hard prerequisites the bus does **not** solve and that the
-deployment must satisfy:
+## 3. Goals & non-goals
 
-- **Sticky load balancing for WebSocket connections.** A WS connection
-  is owned by exactly one node; cross-node WS handover is out of scope
-  for this spike. Drain = brief disconnect; the existing
-  initial-snapshot path on reconnect covers state recovery. HTTP
-  traffic does **not** need to be sticky.
-- **Shared session store across all nodes (and across all services).**
-  `HttpUserContext` is already pluggable on the session store; the
-  multi-node story assumes every process points at the same backing
-  store (Redis, Postgres, etc.). Without this, identity resolution
-  diverges per node and no amount of bus traffic fixes it.
-- **Shared persistent stores per `DataSet`.** Entity-sync notifies of
-  changes; it is not an event-sourced store. The actual entity data
-  must live in a multi-node-safe store (DB, etc.).
+### Goals
 
-## Architecture: shared transport, specialized facades
+- Provide a single, transport-agnostic publish/subscribe primitive
+  (`@furystack/cross-node-bus`) that every FuryStack subsystem and
+  application can share.
+- Ship a usable in-process default and a production-grade Redis Streams
+  adapter alongside it.
+- Replace the in-process `EventHub` paths in entity-sync and identity
+  flows with bus-backed facades, **without breaking existing app code**
+  that uses the local `HttpUserContext` events directly.
+- Make app-defined facades a first-class extension point: app authors
+  build typed wrappers over the bus the same way framework facades do.
+- Enforce capability requirements at registration time so misconfigured
+  deployments fail loudly, not silently.
+
+### Non-goals
+
+- Solve sticky load balancing, gateway/proxy concerns, or distributed
+  locks (see §15 _Out of scope_).
+- Replace persistent stores or become an event-sourcing primitive.
+- Provide competing-consumer / work-queue semantics (see §15 _Out of scope_).
+- Introduce schema-aware typed topic registries on the wire — facades
+  do typing.
+
+## 4. Success metrics
+
+The v1 release is "done" when all three numbers hold in the smoke test
+harness described in §13:
+
+| Metric                                                         | Target                             |
+| -------------------------------------------------------------- | ---------------------------------- |
+| p95 publish-to-receive lag, local Redis                        | **< 50 ms**                        |
+| p95 publish-to-receive lag, in-region Redis                    | **< 200 ms**                       |
+| Identity staleness window (logout → remote cache invalidation) | from **30 s** TTL to **< 1 s** p99 |
+| Cross-service topic leaks in the multi-service smoke test      | **0**                              |
+
+Coverage gates:
+
+- In-process adapter: 100 % line coverage.
+- `IdentityEventBus` facade: 100 % line coverage.
+- Redis adapter: integration tests gated on `docker-compose up redis`,
+  same shape as `redis-store` today.
+- **Multi-node integration tests with > 2 in-process bus instances are
+  mandatory** for both facades.
+
+## 5. Personas & user stories
+
+### P1. App developer running a monolith at scale
+
+> _I have one FuryStack service deployed as N pods behind a load
+> balancer. Identity, entity sync, and my own caches all live in
+> memory today. When users log out on one pod, other pods keep
+> serving stale identity until TTL expires. When my admin tool
+> updates an entity on pod 3, nobody else's WebSocket subscribers see
+> it until a reload._
+
+**Story:** P1 binds a Redis adapter at startup; identity events,
+entity changes, and any custom `EventHub`-style coordination
+propagate across pods automatically. No per-call API change.
+
+### P2. App developer running microservices behind a public gateway
+
+> _I have N FuryStack services, each scaled to M pods, sitting behind
+> one public gateway. They share a session store and a common
+> identity domain. When a user changes their password on the
+> auth-service, every pod of every service must drop its cached
+> identity for that user. When the catalog-service updates a product,
+> every catalog-service pod must fan that change out to its WebSocket
+> clients — but the order-service must not._
+
+**Story:** P2 points every service at one shared broker. Each service
+binds the adapter with a distinct `topicPrefix`. Identity events
+carry through the gateway-fronted fleet. Entity changes stay scoped
+to the service that owns the model. No service learns the others'
+internal topics, but cross-service eavesdrop is one explicit method
+call away when the use case is real.
+
+### P3. Library author building a custom typed facade
+
+> _I'm shipping a FuryStack package that needs cross-node
+> coordination — feature-flag flips, config reloads, custom domain
+> events. I want the same DX as `EventHub<T>` (typed event map, typed
+> handlers) without rebuilding the transport plumbing._
+
+**Story:** P3 defines a `MyFeatureBus` facade that wraps an internal
+`EventHub<MyEvents>` and bridges it to `CrossNodeBus.publish` /
+`CrossNodeBus.subscribe`. App consumers get the familiar `EventHub`
+API; the framework owns the wire format.
+
+## 6. Architecture overview
 
 ```
-+-------------------------+   +--------------------------+   +--------------------------+
-| ChangeBroadcaster       |   | IdentityEventBroadcaster |   | App-defined facades      |
-| (entity-sync-service)   |   | (rest-service)           |   |                          |
-| - sequencing            |   | - typed events           |   | - custom topics          |
-| - replay window         |   | - cache invalidation     |   |                          |
-+-----------+-------------+   +-------------+------------+   +-------------+------------+
-            |                               |                              |
-            +----------+-----------+--------+------------+-----------------+
-                       |           |                     |
-                       v           v                     v
-                +------------------------------------------------+
-                |  @furystack/cross-node-bus (CrossNodeBus token) |
-                |  publish(topic, msg) / subscribe(topic, h) / id |
-                +-----------------+-------------------------------+
-                                  |
-                +-----------------+-----------------+
-                |                                   |
-                v                                   v
-        InProcessAdapter                    Adapter packages
-        (default)                            (separate publishable units)
++-------------------------+   +-------------------+   +-----------------------+
+| EntityChangeBus         |   | IdentityEventBus  |   | App-defined facades   |
+| (entity-sync-service)   |   | (rest-service)    |   |                       |
+| - sequencing            |   | - typed events    |   | - typed events        |
+| - replay window         |   | - cache invalidn. |   | - app topics          |
++-----------+-------------+   +---------+---------+   +-----------+-----------+
+            |                           |                         |
+            +-----------+---------------+-------------+-----------+
+                        |               |             |
+                        v               v             v
+            +-----------------------------------------------------+
+            | @furystack/cross-node-bus (CrossNodeBus token)      |
+            | publish(topic, msg) / subscribe(topic, h) / nodeId  |
+            +---------------------------+-------------------------+
+                                        |
+                +-----------------------+-----------------------+
+                |                                               |
+                v                                               v
+        InProcessCrossNodeBus                          Adapter packages
+        (default factory)                              (separate npm packages)
+                                                       e.g. @furystack/redis-cross-node-bus
 ```
 
 - **`@furystack/cross-node-bus`** owns the abstraction: minimal
-  `CrossNodeBus` interface, default `InProcessAdapter`, and the DI
-  token. No transport-specific code.
-- **Adapter packages** (`@furystack/cross-node-bus-redis`,
-  `@furystack/cross-node-bus-nats`, …) live separately and are bound
-  by the application:
-
-  ```ts
-  injector.bind(CrossNodeBus, () => new RedisStreamsBus({ url: '…' }))
-  ```
-
+  `CrossNodeBus` interface, default `InProcessCrossNodeBus`, the DI
+  token, and capability declarations. No transport-specific code
+  lives in the core package.
+- **Adapter packages** (`@furystack/redis-cross-node-bus`, future
+  `-nats-`, `-kafka-`) live in their own publishable units with their
+  own dependencies and own integration tests.
 - **Subsystem facades** are typed, opinionated wrappers. Each owns its
   own concerns (sequencing, replay, cache invalidation logic) and
   consumes the shared `CrossNodeBus` token.
-- **Apps can also use `CrossNodeBus` directly** for custom domain
-  events without spinning up a facade.
+- **Apps may also use `CrossNodeBus` directly** for one-off coordination,
+  but the recommended path is to define a facade per concern.
 
-This mirrors how `@furystack/logging` / `@furystack/cache` are
-structured today — pluggable backend behind a typed token, with
-feature-specific consumers.
+This mirrors how `defineStore` + `defineFileSystemStore` /
+`defineRedisStore` are layered today.
 
-## Topology — multi-service deployment with a public gateway
+### Multi-service deployment shape
 
-The framework target is **N services × M nodes per service behind a
-public gateway**. The bus does not impose a topology, but the
-deployment guidance is:
-
-```
-                    +----------------+
-                    | public gateway |  (rest-service proxy module)
-                    | - L7 routing   |
-                    | - bus consumer |
-                    +-------+--------+
-                            |
-        +-------------------+-------------------+
-        |                   |                   |
-   +----+----+         +----+----+         +----+----+
-   | svc-a   |         | svc-b   |         | svc-c   |
-   | × N pods|         | × N pods|         | × N pods|
-   +----+----+         +----+----+         +----+----+
-        |                   |                   |
-        +---------+---------+---------+---------+
-                  |                   |
-                  v                   v
-            +-----------+       +-------------+
-            | shared    |       | shared      |
-            | session / |       | bus broker  |
-            | identity  |       | (e.g. Redis |
-            | store     |       |  Streams)   |
-            +-----------+       +-------------+
-```
-
-### Single shared bus, per-service topic prefix
-
-One broker instance serves the whole fleet. Each service binds its
-adapter with a topic prefix from configuration:
+The framework is designed for the **N services × M nodes per service**
+deployment described by P2. A single broker serves the whole fleet;
+every service binds its adapter with a distinct `topicPrefix`:
 
 ```ts
 injector.bind(
   CrossNodeBus,
-  () =>
-    new RedisStreamsBus({
-      url: '…',
-      topicPrefix: 'svc-a/',
-      serviceName: 'svc-a',
-    }),
+  defineRedisCrossNodeBusAdapter({
+    topicPrefix: 'svc-a/',
+    serviceName: 'svc-a',
+  }),
 )
 ```
 
-Facades subscribe/publish under their own sub-namespace
-(`entity/User`, `identity/`, `app/`); the adapter prefixes every
-topic with `topicPrefix` on the wire. Cross-service eavesdropping
-remains possible (single broker), but accidental collisions with
-other services' topics are not.
+Facades publish/subscribe under their own sub-namespace
+(`identity/`, `entity/User`, `app/…`); the adapter prefixes every
+topic with `topicPrefix` on the wire. Cross-service eavesdrop is
+opt-in and explicit (see §8 _Cross-prefix subscribe_).
 
 ### `nodeId` convention
 
 `nodeId = ${serviceName}-${random}` (random tail per process start).
-Stable per process, unique across services, debuggable in
-telemetry. The factory should default to this when
-`serviceName` is provided to the adapter.
+Stable per process, unique across services, debuggable in telemetry.
+The factory defaults to this when `serviceName` is provided to the
+adapter; apps may override for tests.
 
-### Gateway service
+## 7. API contract
 
-The gateway is a Furystack service implemented on top of
-`@furystack/rest-service` plus a routing module. MVP scope:
-
-- L7 path/host routing to backend services.
-- Forwards request as-is — services keep owning auth, no
-  identity-header trust between gateway and services.
-- Itself a participant on the shared bus once it has any local state
-  worth invalidating (e.g. a per-route cache, a session lookup
-  cache). Subscribes to `IdentityEventBroadcaster` events to
-  invalidate the same way every other node does.
-
-Auth-terminating gateway, per-request token exchange, and
-service-to-service signed identity headers are deliberately
-out of scope for the MVP — they duplicate logic that already lives
-behind a shared session store.
-
-## The bus interface
+### `CrossNodeBus` interface
 
 ```ts
 export interface CrossNodeBus extends Disposable {
   /** Stable, unique id of this node. Included in every published message. */
   readonly nodeId: string
 
+  /** Static description of what this adapter can do. */
+  readonly capabilities: CrossNodeBusCapabilities
+
   /**
-   * Publishes `message` on `topic`. Returns once the message has been
-   * accepted by the underlying transport (not when it has been delivered).
+   * Publishes `payload` on `topic`. Returns once the message has been
+   * accepted by the underlying transport (not when it has been delivered
+   * to all subscribers).
    */
-  publish(topic: string, message: BusMessage): Promise<void>
+  publish(topic: string, payload: unknown): Promise<void>
 
   /**
    * Subscribes to every message published on `topic`, including ones
    * originating from this node. Subscribers must filter by `originId`
-   * themselves if they want local/remote distinction.
+   * themselves if they want a local/remote distinction.
    */
   subscribe(topic: string, handler: (message: BusMessage) => void): Disposable
+
+  /**
+   * Convenience for the common "I only care about messages from other
+   * nodes" pattern. Equivalent to subscribe + filter on
+   * `message.originId !== this.nodeId`.
+   */
+  subscribeRemoteOnly(topic: string, handler: (message: BusMessage) => void): Disposable
+
+  /**
+   * Subscribe to a topic owned by another `topicPrefix`. Explicit, greppable
+   * cross-service eavesdrop. Adapters that do not support cross-prefix
+   * routing may throw at registration time.
+   */
+  subscribeForeign(prefix: string, topic: string, handler: (message: BusMessage) => void): Disposable
+
+  /**
+   * Replay messages on `topic` from `fromSeq` (exclusive) up to the most
+   * recent. Throws if `bus.capabilities.replay` is `false`. May reject
+   * with a `ReplayWindowExceededError` if `fromSeq` is older than the
+   * adapter's retained window — facades fall back to a full snapshot.
+   */
+  replay(topic: string, fromSeq: string): AsyncIterable<BusMessage>
 }
 
 export interface BusMessage {
@@ -200,36 +266,86 @@ export interface BusMessage {
   readonly originId: string
   /** ISO-8601 publish timestamp from the publisher's clock (diagnostic only). */
   readonly emittedAt: string
+  /**
+   * Adapter-assigned per-topic monotonic id. Optional because non-sequencing
+   * adapters do not provide one.
+   */
+  readonly seq?: string
   /** Caller-supplied payload. Must be JSON-serializable. */
   readonly payload: unknown
 }
+
+export interface CrossNodeBusCapabilities {
+  readonly persistent: boolean
+  readonly replay: boolean
+  readonly assignsSequence: boolean
+}
 ```
 
-Deliberately minimal:
+Design choices:
 
-- No request/response. Pure pub/sub.
-- No persistence guarantees on the interface — adapters declare their
-  own. Consumers that need replay (entity-sync) must check the
-  capability or pin the adapter.
-- No typed topics on the interface. Facades layer types on top
-  (`IdentityEventBroadcaster.publish('userLoggedOut', { sessionId })`).
-- `subscribe` returns a `Disposable`; teardown via `[Symbol.dispose]`.
+- **Pure pub/sub.** No request/response.
+- **Untyped wire format.** Typing is the facade's job; the wire stays
+  flexible enough to host any payload shape.
+- **`subscribe` returns a `Disposable`** for `using` / `useDisposable`
+  ergonomics. Legacy `addListener` / `removeListener` parity is not
+  exposed.
+- **Self-delivery on by default.** Single fan-out path keeps publish
+  and local subscriber semantics identical regardless of where the
+  subscriber lives.
+- **Hard pin on `BusMessage.v`.** See §12 for the rolling-deploy strategy.
 
-## Adapters
+### Token & default factory
 
-Recommended order of implementation:
+```ts
+export const CrossNodeBus = defineService({
+  name: '@furystack/cross-node-bus',
+  lifetime: 'singleton',
+  factory: () => new InProcessCrossNodeBus(),
+})
+```
 
-| Adapter                  | Persistence        | Server seq | Replay | Setup cost          | Identity facade | Change facade | First impl?                   |
-| ------------------------ | ------------------ | ---------- | ------ | ------------------- | --------------- | ------------- | ----------------------------- |
-| In-process               | n/a                | local      | yes\*  | none                | yes             | yes           | ✅ ships with the bus package |
-| Redis Streams            | ✅                 | yes        | ✅     | low                 | yes             | yes           | ✅ first concrete adapter     |
-| Redis pub/sub            | ❌                 | no         | ❌     | low                 | yes             | no            | maybe                         |
-| NATS JetStream           | ✅                 | yes        | ✅     | medium              | yes             | yes           | later                         |
-| Kafka                    | ✅                 | yes        | ✅     | high                | yes             | yes           | later                         |
-| RabbitMQ Streams         | ✅                 | yes        | ✅     | medium              | yes             | yes           | later                         |
-| RabbitMQ (classic AMQP)  | ❌                 | no         | ❌     | low                 | yes             | no            | later                         |
-| MQTT                     | ❌                 | no         | ❌     | low                 | yes             | no            | later                         |
-| Postgres `LISTEN/NOTIFY` | ❌ (advisory only) | no         | ❌     | low (already in DB) | yes             | no            | later                         |
+If an app does not bind a transport adapter, `InProcessCrossNodeBus`
+is used. Single-node deployments work out of the box with no
+configuration. Multi-node deployments are expected to bind a real
+adapter — in-process means "no cross-node delivery."
+
+### Adapter factory helper
+
+Adapters expose a `defineXxxCrossNodeBusAdapter` helper analogous to
+`defineFileSystemStore` / `defineRedisStore`:
+
+```ts
+import { defineRedisCrossNodeBusAdapter } from '@furystack/redis-cross-node-bus'
+
+injector.bind(
+  CrossNodeBus,
+  defineRedisCrossNodeBusAdapter({
+    url: 'redis://redis:6379',
+    topicPrefix: 'svc-a/',
+    serviceName: 'svc-a',
+    replayWindow: 10_000,
+  }),
+)
+```
+
+The helper validates config at construction time and centralizes the
+lifecycle (`onDispose` cleanup). All configuration is **env-agnostic**
+and constructor-passed; adapters never read `process.env` directly.
+
+## 8. Adapters
+
+| Adapter                  | Persistence        | Server seq | Replay | Setup cost          | `IdentityEventBus` | `EntityChangeBus` | First impl?                   |
+| ------------------------ | ------------------ | ---------- | ------ | ------------------- | ------------------ | ----------------- | ----------------------------- |
+| In-process               | n/a                | local      | yes\*  | none                | yes                | yes               | ✅ ships with the bus package |
+| Redis Streams            | ✅                 | yes        | ✅     | low                 | yes                | yes               | ✅ first concrete adapter     |
+| Redis pub/sub            | ❌                 | no         | ❌     | low                 | yes                | no                | maybe                         |
+| NATS JetStream           | ✅                 | yes        | ✅     | medium              | yes                | yes               | later                         |
+| Kafka                    | ✅                 | yes        | ✅     | high                | yes                | yes               | **out of v1**                 |
+| RabbitMQ Streams         | ✅                 | yes        | ✅     | medium              | yes                | yes               | later                         |
+| RabbitMQ (classic AMQP)  | ❌                 | no         | ❌     | low                 | yes                | no                | later                         |
+| MQTT                     | ❌                 | no         | ❌     | low                 | yes                | no                | later                         |
+| Postgres `LISTEN/NOTIFY` | ❌ (advisory only) | no         | ❌     | low (already in DB) | yes                | no                | later                         |
 
 \* The in-process adapter is single-process by definition; "replay"
 means the local ring buffer used by reconnecting clients.
@@ -238,168 +354,56 @@ Redis Streams is the recommended first concrete adapter — small ops
 surface, native sequencing, native replay, easy local development with
 docker-compose.
 
-**Capability contract per facade:**
+### Cross-prefix subscribe
 
-- `IdentityEventBroadcaster` works on **any** transport — events are
-  fire-and-forget, all handlers are idempotent, no ordering or
-  replay required.
-- `ChangeBroadcaster` requires `capabilities.replay === true && capabilities.assignsSequence === true`
-  and asserts both at registration; otherwise it refuses to start.
-  Adapters that lack one are fine for `IdentityEventBroadcaster`
-  and app-defined facades but cannot serve entity-sync.
-
-This makes "shared bus across services" workable even when the
-chosen broker (e.g. RabbitMQ AMQP, MQTT) cannot serve entity-sync —
-non-replay-needing facades still ride the same transport.
-
-### Capability advertisement
+`subscribe(topic, …)` resolves under the adapter's own `topicPrefix`.
+Cross-service eavesdrop is supported via:
 
 ```ts
-export interface CrossNodeBusCapabilities {
-  readonly persistent: boolean
-  readonly replay: boolean
-  readonly assignsSequence: boolean
-}
-
-export interface CrossNodeBus extends Disposable {
-  readonly capabilities: CrossNodeBusCapabilities
-  // …
-}
+bus.subscribeForeign('auth-service/', 'identity/userLoggedOut', handler)
 ```
 
-Consumers that need replay assert
-`bus.capabilities.replay === true` at registration time and refuse to
-start otherwise.
+The method is deliberately verbose so that any cross-service coupling
+shows up in `grep`. Adapters that lack the underlying capability must
+throw a clear error at registration time.
 
-## Consumer 1 — `ChangeBroadcaster` (entity-sync)
+### Replay-window defaults
 
-Replaces `SubscriptionManager`'s direct `dataSet.subscribe(...)`
-callbacks with a single fan-out path through the bus.
+| Adapter       | Default window                       | Configurable via               |
+| ------------- | ------------------------------------ | ------------------------------ |
+| In-process    | 1 000 messages / topic (ring buffer) | constructor `{ replayWindow }` |
+| Redis Streams | `MAXLEN ~ 10000` per stream          | constructor `{ replayWindow }` |
 
-### Today's wiring
+Out-of-window replay rejects with `ReplayWindowExceededError`; facades
+fall back to a full snapshot path.
 
-```ts
-registration.eventSubscriptions = [
-  dataSet.subscribe('onEntityAdded', ({ entity }) => {
-    this.handleEntityAdded(modelName, entity, entity[primaryKey])
-  }),
-  // …
-]
-```
+## 9. Capability matrix & enforcement
 
-`handleEntityAdded` walks `this.subscriptions` (process-local) and
-pushes notifications to local sockets only.
+Capabilities are **declared statically** by every adapter and
+**asserted at facade registration time**. There is **no silent
+degradation**: a facade that needs replay and is bound to a
+non-replaying adapter must refuse to start.
 
-### Proposed wiring
+| Facade              | Required capabilities                         |
+| ------------------- | --------------------------------------------- |
+| `IdentityEventBus`  | none — works on any adapter                   |
+| `EntityChangeBus`   | `replay === true && assignsSequence === true` |
+| App-defined facades | facade declares its own requirement           |
 
-```ts
-dataSet.subscribe('onEntityAdded', ({ entity }) => {
-  // publish to bus first; local fan-out happens via the subscribe()
-  // callback below — single fan-out path
-  void this.broadcaster.publish(modelName, {
-    type: 'added',
-    entity,
-    primaryKey: (entity as Record<string, unknown>)[primaryKey],
-  })
-})
+Hard refusal means a clearer ops experience: a misconfigured
+deployment fails loudly at boot rather than serving stale data
+forever.
 
-const handle = this.broadcaster.subscribe(modelName, (change) => {
-  this.handleBroadcastChange(modelName, change)
-})
-```
+## 10. Facade specs
 
-`handleEntityAdded` / `handleEntityUpdated` / `handleEntityRemoved`
-become handlers on `BroadcastChange` events. Their existing logic
-(build `ServerSyncMessage`, walk `this.subscriptions`, push to sockets)
-stays as-is.
+### 10.1 `IdentityEventBus` (rest-service)
 
-### `BroadcastChange` payload
+Closes the gap between local `HttpUserContext` events (which fire
+only on the originating node) and cross-instance state. Collapses
+the identity-staleness window from `userCacheTtlMs` (default 30 s)
+to bus latency for sub-TTL freshness.
 
-```ts
-export type BroadcastChange =
-  | { type: 'added'; entity: unknown; primaryKey: string }
-  | { type: 'updated'; id: unknown; change: Record<string, unknown> }
-  | { type: 'removed'; id: unknown }
-```
-
-Wrapped in `BusMessage` by the bus (versioning, originId, timestamp
-already there — no need to duplicate on the payload).
-
-### Sequence numbers
-
-`registration.currentSeq` is per-process today. With multiple nodes,
-each subscriber sees gaps and out-of-order deltas. Options:
-
-- **(A) Authoritative sequence in the bus.** Adapters that support
-  `assignsSequence` provide a server-assigned monotonic seq. The
-  in-process adapter keeps a local counter (matching today's behavior).
-  **Recommended.**
-- **(B) Logical clock per node + reconcile.** Hard. Don't.
-- **(C) Drop seq, use timestamps.** Breaks delta sync replay. Rejected.
-
-(A) means `incrementVersion` moves out of `SubscriptionManager` and
-into the broadcaster; the broadcaster stamps `version: SyncVersion` on
-the outbound `ServerSyncMessage` using the bus-assigned seq.
-
-### Server-side seq dedup
-
-The bus is at-least-once; retransmits and reconnect-driven replay can
-deliver the same `BroadcastChange` to a node twice. Rather than rely
-on client-side dedup, the broadcaster tracks `lastSeenSeq` per
-`(topic, originId)` and drops any `seq <= lastSeenSeq` before pushing
-to local WS subscribers. Cheap (one map lookup per message), kills
-retransmit-induced bursts, removes the need for clients to know how
-to deduplicate. ~10 LOC, runs in the bus-subscribe handler before
-the existing `handleBroadcastChange` call.
-
-### Replay window
-
-Drop the per-process `changelog` in favor of bus replay as the single
-source of truth.
-
-- Reconnecting clients with a known last-seen seq → broadcaster asks
-  the bus for messages from that seq onward (`bus.replay(topic, fromSeq)`).
-- The in-process adapter implements `replay` via a local ring buffer —
-  this is what `changelog` is today; same data structure, owned by the
-  bus instead of `SubscriptionManager`.
-- Adapters that don't support replay refuse to host `ChangeBroadcaster`
-  at registration time (capability assertion above), so the broadcaster
-  can rely on `bus.replay` always being available when it runs.
-- If the requested `fromSeq` is older than the bus's retained window,
-  the broadcaster falls back to the existing full-snapshot path.
-
-This removes the "covered by local changelog?" branching that hides
-multi-node correctness bugs single-node tests can't catch — the
-writing node's changelog is the only one that contains a write, so
-any code path that prefers it skips writes from siblings.
-
-### Open design questions
-
-1. **Payload size.** `onEntityAdded` carries the full entity; for some
-   models that may include large blobs. Worth defining a "broadcast
-   payload" hook on `DataSetSettings` so models can opt to broadcast
-   only `id` and have other nodes fetch the entity locally.
-2. **Authorization at publish time.** Today `authorizeGet` runs on the
-   receiving node when re-evaluating a collection (using the captured
-   identity from PR #639). With cross-node fan-out, the writing node
-   doesn't know which subscribers exist on which nodes. The receiving
-   node must continue to filter by identity. Don't filter on publish.
-3. **Backpressure.** Bursty models could flood the bus. Existing
-   `debounceMs` / `queryTtlMs` collection-evaluation knobs help;
-   consider exposing a per-model bus-rate-limit later. Guardrail for
-   the eventual implementer: when a model exceeds bus throughput, the
-   correct strategy is **coalesce** (publish only the latest change
-   per primary key within a window), **not drop** — entity-sync state
-   is a "what's the current value?" channel, not an audit log.
-
-## Consumer 2 — `IdentityEventBroadcaster` (rest-service)
-
-Closes the gap between local `HttpUserContext` events (which fire only
-on the originating node) and cross-instance state. Collapses the
-identity-staleness window from `userCacheTtlMs` (default 30 s) to
-"bus latency" for the events where sub-TTL freshness matters.
-
-### Event shapes
+#### Event shapes
 
 ```ts
 export type IdentityEvent =
@@ -410,10 +414,10 @@ export type IdentityEvent =
   | { type: 'passwordChanged'; username: string }
 ```
 
-### Wiring
+#### Wiring (publish side)
 
-`HttpUserContext.cookieLogout` already invalidates the local cache
-entry. Extend it to also publish:
+`HttpUserContext.cookieLogout` keeps its existing local emit, **and**
+publishes to the bus:
 
 ```ts
 public async cookieLogout(request, response): Promise<void> {
@@ -422,134 +426,214 @@ public async cookieLogout(request, response): Promise<void> {
 
   if (sessionId) {
     this.userCache.invalidate(`cookie:${sessionId}`)
-    void this.identityEventBroadcaster.publish({ type: 'userLoggedOut', sessionId })
+    void this.identityEventBus.publish({ type: 'userLoggedOut', sessionId })
   }
   this.emit('onLogout', undefined)
 }
 ```
 
-Subscribers on every node react:
+The local `EventHub` emit is preserved — apps that already subscribe
+to `httpUserContext` events keep working unchanged. Cross-node
+fan-out is purely additive.
+
+#### Wiring (subscribe side)
 
 ```ts
-identityEventBroadcaster.subscribe((event) => {
-  switch (event.type) {
-    case 'userLoggedOut':
-    case 'sessionInvalidated':
-      userCache.invalidate(`cookie:${event.sessionId}`)
-      // Optional: walk WebSocket connections, close any whose
-      // `request.headers.cookie` carries this sessionId.
-      break
-    case 'userRolesChanged':
-    case 'userDeleted':
-    case 'passwordChanged':
-      userCache.invalidateByUser(event.username)
-      break
-  }
+identityEventBus.subscribe('userLoggedOut', ({ sessionId }) => {
+  userCache.invalidate(`cookie:${sessionId}`)
+})
+
+identityEventBus.subscribe('sessionInvalidated', ({ sessionId }) => {
+  userCache.invalidate(`cookie:${sessionId}`)
+})
+
+identityEventBus.subscribe('userRolesChanged', ({ username }) => {
+  userCache.invalidateByUser(username)
+})
+
+identityEventBus.subscribe('userDeleted', ({ username }) => {
+  userCache.invalidateByUser(username)
+})
+
+identityEventBus.subscribe('passwordChanged', ({ username }) => {
+  userCache.invalidateByUser(username)
 })
 ```
 
-### `invalidateByUser`
+#### `invalidateByUser`
 
 `UserResolutionCache` keys by `cookie:${sessionId}`. Invalidate by
-username via `Cache.removeRange` with a predicate over the cached
-value:
+username via `Cache.removeByTag` against a `getTags`-derived
+`user:${username}` tag:
 
 ```ts
+type UserCacheTag = `user:${string}`
+
+const cache = new Cache<User, [string], UserCacheTag>({
+  load: (sessionId) => resolveSession(sessionId),
+  getKey: (sessionId) => `cookie:${sessionId}`,
+  getTags: (user) => [`user:${user.username}`],
+})
+
 public invalidateByUser(username: string): void {
-  this.cache.removeRange((value) => value.username === username)
+  this.cache.removeByTag(`user:${username}`)
 }
 ```
 
-`Cache.removeRange` already passes `(value, args)` to the predicate
-(see `cache-state-manager.ts` and the spec `Should expose the original
-args in obsoleteRange / removeRange predicates with a custom getKey`),
-so custom `getKey` is a non-issue. The cache is bounded (per-process,
-short TTL, low cardinality) — an O(n) scan on rare invalidation
-events is irrelevant. No secondary index, no extra invariant to
-maintain.
+The tag is a plain string, so the same invalidation can be replayed
+on every node by publishing `user:${username}` over the bus. Tag
+matching uses the cache's reverse index — no per-call O(n) scan.
 
-### Consumers also wire to existing `HttpUserContext` events
-
-`HttpUserContext` already emits `onLogin` / `onLogout` /
-`onSessionInvalidated`. Wire them to the broadcaster as the publish
-side; no need for callers to learn a new API. Apps that already
-listen to `HttpUserContext` events continue to receive them
-**locally**; cross-node fan-out is additive.
-
-### What does **not** propagate via this broadcaster
+#### What does **not** propagate
 
 - `onLogin` is intentionally **not** published. A cache populated for
   a fresh session is harmless on remote nodes; let TTL handle it.
-- Bulk operations ("invalidate everything for tenant X") should publish
-  a single high-level event rather than fanning out N
+- Bulk operations ("invalidate everything for tenant X") should
+  publish a single high-level event rather than fanning out N
   per-user/per-session events.
 
-## Consumer 3 — application-defined facades
+### 10.2 `EntityChangeBus` (entity-sync-service)
 
-Apps can use `CrossNodeBus` directly. Pattern:
+Replaces `SubscriptionManager`'s direct `dataSet.subscribe(...)`
+callbacks with a single fan-out path through the bus.
+
+#### Wiring
+
+```ts
+dataSet.subscribe('onEntityAdded', ({ entity }) => {
+  void this.entityChangeBus.publish(modelName, {
+    type: 'added',
+    entity,
+    primaryKey: (entity as Record<string, unknown>)[primaryKey],
+  })
+})
+
+const handle = this.entityChangeBus.subscribe(modelName, (change) => {
+  this.handleBroadcastChange(modelName, change)
+})
+```
+
+`handleEntityAdded` / `handleEntityUpdated` / `handleEntityRemoved`
+become handlers on `EntityChange` events. Their existing logic
+(build `ServerSyncMessage`, walk `this.subscriptions`, push to
+sockets) stays as-is.
+
+#### `EntityChange` payload
+
+```ts
+export type EntityChange =
+  | { type: 'added'; entity: unknown; primaryKey: string }
+  | { type: 'updated'; id: unknown; change: Record<string, unknown> }
+  | { type: 'removed'; id: unknown }
+```
+
+The bus wraps it in `BusMessage` (versioning, originId, timestamp,
+seq) — no need to duplicate any of that on the payload.
+
+#### Sequence numbers
+
+`registration.currentSeq` is per-process today. With multiple
+nodes, each subscriber sees gaps and out-of-order deltas.
+
+The chosen approach is **adapter-assigned sequence**: adapters that
+support `assignsSequence` provide a server-assigned monotonic
+`seq` per topic. The in-process adapter keeps a local counter
+(matching today's behavior). `incrementVersion` moves out of
+`SubscriptionManager` and into the broadcaster; the broadcaster
+stamps `version: SyncVersion` on the outbound `ServerSyncMessage`
+using the bus-assigned seq.
+
+#### Server-side seq dedup
+
+The bus is at-least-once; retransmits and reconnect-driven replay
+can deliver the same `EntityChange` twice. The broadcaster tracks
+`lastSeenSeq` per `(topic, originId)` and drops any
+`seq <= lastSeenSeq` before pushing to local WS subscribers.
+
+To prevent unbounded growth as nodes come and go, entries are
+TTL-evicted after **1 hour of no messages** from that
+`(topic, originId)`. Worst case after eviction = duplicate delivery
+for that pair, which the rest of the system already tolerates.
+
+#### Replay window
+
+The per-process `changelog` in `SubscriptionManager` is dropped in
+favor of `bus.replay` as the single source of truth.
+
+- Reconnecting clients with a known last-seen seq → broadcaster calls
+  `bus.replay(topic, fromSeq)`.
+- The in-process adapter implements `replay` via a local ring buffer
+  (1 000 messages per topic by default) — same data structure as
+  today's `changelog`, owned by the bus.
+- Adapters that don't support replay refuse to host
+  `EntityChangeBus` at registration (capability assertion above), so
+  the broadcaster can rely on `bus.replay` always being available.
+- If the requested `fromSeq` is older than the bus's retained window,
+  the broadcaster falls back to the existing full-snapshot path.
+
+This removes the "covered by local changelog?" branching that hides
+multi-node correctness bugs single-node tests can't catch — the
+writing node's changelog is the only one that contains a write, so
+any code path that prefers it skips writes from siblings.
+
+### 10.3 App-defined facades
+
+Apps build custom facades by composing an internal `EventHub<T>` (for
+typed local DX and listener error isolation) with a `CrossNodeBus`
+binding. Sketch:
 
 ```ts
 type AppEvent = { type: 'featureFlagChanged'; flag: string; value: boolean } | { type: 'configReloaded' }
 
-const APP_TOPIC = 'my-app/events'
+const APP_TOPIC = 'app/events'
 
-const bus = injector.get(CrossNodeBus)
+export const AppEventBus = defineService({
+  name: 'my-app/AppEventBus',
+  lifetime: 'singleton',
+  factory: ({ inject, onDispose }) => {
+    const bus = inject(CrossNodeBus)
+    const local = new EventHub<{ event: AppEvent }>()
 
-await bus.publish(APP_TOPIC, {
-  v: 1,
-  originId: bus.nodeId,
-  emittedAt: new Date().toISOString(),
-  payload: { type: 'featureFlagChanged', flag: 'new-ui', value: true } satisfies AppEvent,
-})
+    const handle = bus.subscribe(APP_TOPIC, (message) => {
+      local.emit('event', message.payload as AppEvent)
+    })
 
-const handle = bus.subscribe(APP_TOPIC, ({ payload }) => {
-  const event = payload as AppEvent
-  // …
+    onDispose(() => {
+      handle[Symbol.dispose]()
+      local[Symbol.dispose]()
+    })
+
+    return {
+      subscribe: (h: (e: AppEvent) => void) => local.subscribe('event', h),
+      publish: (event: AppEvent) => bus.publish(APP_TOPIC, event),
+    }
+  },
 })
 ```
 
-Documented as "build your own facade" rather than building a
-generic-typed-topic registry into the bus — TypeScript's string-keyed
-topic registries always compromise either type safety or DX.
+This is the recommended pattern for any cross-node coordination an
+app needs. A small `@furystack/cross-node-bus/testing` subpath ships
+a two-instance in-process harness so facade authors can write
+multi-node integration tests without spinning up a broker.
 
-## Cross-cutting concerns
+## 11. Cross-cutting concerns
 
 ### Delivery semantics
 
-- **At-least-once vs at-most-once:** entity-sync clients tolerate
-  duplicates (state-snapshot diffing already deduplicates). Identity
-  events are idempotent (invalidating an already-invalid entry is a
-  no-op). Prefer **at-least-once**.
-- **Ordering:** per-topic FIFO from a given publisher is sufficient.
-  Total ordering across publishers is **not** required for any current
+- **At-least-once**, not at-most-once. Entity-sync clients tolerate
+  duplicates (state-snapshot diffing already deduplicates and the
+  broadcaster does server-side dedup). Identity events are idempotent
+  (invalidating an already-invalid entry is a no-op).
+- **Per-topic FIFO from a given publisher** is sufficient. Total
+  ordering across publishers is **not** required for any current
   consumer.
-
-### Schema versioning
-
-`BusMessage.v` is a hard pin. Adapters refuse incompatible versions
-with a logged error and a metric. Bumping the wire-format version is a
-breaking change for the bus package; consumers continue to pin their
-own payload shapes inside `payload`.
 
 ### Origin filter
 
 The bus delivers a publisher's own messages back to it (single
 fan-out path). Consumers that need to deduplicate local-vs-remote use
-`message.originId === bus.nodeId`. The default is **not** to filter —
-this avoids surprises when a node both writes and serves a subscriber.
-
-For the common "I only care about messages from other nodes" pattern,
-the bus exposes a small helper:
-
-```ts
-bus.subscribeRemoteOnly(topic, (message) => {
-  /* ... */
-})
-```
-
-Equivalent to `bus.subscribe(topic, m => { if (m.originId !== bus.nodeId) handler(m) })`.
-~5 LOC, no semantic change to the bus interface — pure convenience
-for app-defined facades.
+`message.originId === bus.nodeId`, or call
+`subscribeRemoteOnly(...)`.
 
 ### Security
 
@@ -566,111 +650,199 @@ Every publish/subscribe path emits structured events to
 - `onCrossNodeReceived` — `{ topic, originId, lagMs }`
 - `onCrossNodeError` — `{ topic, error, phase: 'publish' | 'subscribe' | 'serialize' }`
 
-`lagMs` is `Date.now() - Date.parse(message.emittedAt)` — a coarse but
-useful signal for tuning replication paths.
+`lagMs = Date.now() - Date.parse(message.emittedAt)` and is emitted on
+**every received message** — the cost is sub-microsecond and the
+signal is invaluable when tuning replication paths.
 
-## Suggested spike work-items (incremental)
+`byteLength` is measured **after JSON serialization, before adapter
+framing**, so values are comparable across adapters.
 
-1. **Bus package & in-process adapter**
-   - [ ] Create `@furystack/cross-node-bus` package with the
-         `CrossNodeBus` token, `BusMessage` type, and
-         `InProcessCrossNodeBus` default factory.
-   - [ ] Telemetry hooks (`onCrossNodePublished` /
-         `onCrossNodeReceived` / `onCrossNodeError`).
-   - [ ] Unit tests covering subscribe/publish, multiple subscribers,
-         disposal, originId, error isolation.
-2. **`ChangeBroadcaster` facade** (entity-sync-service)
-   - [ ] Define `ChangeBroadcaster` interface + token (depends on
-         `CrossNodeBus`).
-   - [ ] Refactor `SubscriptionManager.registerModel` to publish +
-         subscribe via the broadcaster; single fan-out path.
-   - [ ] Move sequence-number generation into the broadcaster;
-         in-process bus keeps a local counter.
-   - [ ] Verify all existing tests pass — single-node story unchanged.
-   - [ ] Add a test double that simulates two `CrossNodeBus` instances
-         talking via a shared in-memory channel; integration spec
-         proves cross-node delivery.
-3. **`IdentityEventBroadcaster` facade** (rest-service)
-   - [ ] Define event union + token + factory.
-   - [ ] Wire `HttpUserContext.cookieLogout` to publish.
-   - [ ] Subscribe in the factory; on `userLoggedOut` /
-         `sessionInvalidated` invalidate the local
-         `UserResolutionCache` entry.
-   - [ ] Add `invalidateByUser(username)` to `UserResolutionCache`
-         using `Cache.removeRange` with a value-predicate.
-   - [ ] (Stretch) on `userLoggedOut` walk the
-         `WebSocketApi.clients` map and close any sockets whose
-         `request.headers.cookie` carries the invalidated sessionId.
-4. **First concrete transport adapter**
-   - [ ] `@furystack/cross-node-bus-redis` package using Redis Streams
-         (`XADD` / `XREAD` consumer groups).
-   - [ ] Capability flags reflect persistence / replay / sequencing.
-   - [ ] Adapter constructor accepts `{ url, topicPrefix, serviceName }`;
-         `nodeId` defaults to `${serviceName}-${random}`.
-   - [ ] Manual smoke-test harness with two Node processes against a
-         dockerized Redis verifies entity-sync + identity events flow
-         end-to-end.
-5. **Multi-service smoke-test**
-   - [ ] Two services × two nodes each, single Redis, distinct
-         `topicPrefix` per service. Assert: events stay scoped to
-         their prefix; an `IdentityEvent` published by service A's
-         auth path invalidates caches on every node of service A and
-         only there; service B sees nothing on its own subscriptions.
+## 12. Backward compatibility
 
-## Known residual risks
+The bus is purely **additive** to existing surfaces:
 
-These are not blockers but should be called out before implementation:
+- `HttpUserContext` keeps its local `EventHub`. Apps subscribed to
+  `httpUserContext.subscribe('onLogout', …)` keep working unchanged.
+  Bus publish sits next to the local emit, not in front of it.
+- `DataSet.subscribe('onEntityAdded', …)` keeps working unchanged.
+- Apps that do **not** bind a transport adapter resolve
+  `InProcessCrossNodeBus` and behave exactly like today (single-node).
 
-- **Cold-start ordering on `IdentityEventBroadcaster`.** A node
-  booting after another node has already published an identity event
-  misses that event entirely (no replay required for this facade).
-  Consequence: a freshly booted node serves stale identity until the
-  `UserResolutionCache` TTL expires (default 30 s). This is bounded by
-  design — the cache TTL is the worst-case staleness window. Document
-  but do not fix.
-- **Schema-version skew during rolling deploys.** `BusMessage.v` is a
-  hard pin; mid-rollout, a v1 node and a v2 node share a topic and
-  refuse each other's messages. Two coping strategies:
-  1. Wire-format bumps require a fleet-wide deploy fence (drain
-     everything, deploy v2, resume) — simple, disruptive.
-  2. Always ship one cycle of "v2-aware, v1-emitting" nodes that
-     accept both versions, then a follow-up cycle that emits v2 — no
-     downtime, two deploys per breaking change.
-     Spike does not pick one; the operator does. Pin the choice in
-     release notes when the first v2 lands.
+### Schema-version skew during rolling deploys
 
-## Out of scope
+`BusMessage.v` is a hard pin: a v1 node and a v2 node sharing a topic
+refuse each other's messages. The committed strategy for v1 is the
+**dual-accept release cycle**:
 
-- Distributed locks for write coordination (writes still go through
+1. Cycle N+1: ship a release that **accepts** both `v` and `v+1` but
+   still **emits** `v`.
+2. Cycle N+2: ship a release that **emits** `v+1`. Older nodes from
+   N+1 still accept it.
+3. Cycle N+3: drop `v` acceptance.
+
+No fleet drain required. Pin the dual-accept window in release notes
+when the first `v+1` lands.
+
+### Internal API exports
+
+Whether the `SubscriptionManager` refactor in `entity-sync-service`
+is a major or minor bump depends on what the package's `index.ts`
+re-exports. The implementer must check exports and bump accordingly.
+
+## 13. Release plan & milestones
+
+Numbered ordering implies prerequisites. Each milestone is mergeable
+and releasable on its own.
+
+### Milestone 1 — Bus core & in-process adapter
+
+- [ ] Create `@furystack/cross-node-bus` package with the
+      `CrossNodeBus` token, `BusMessage` type, capabilities,
+      `InProcessCrossNodeBus` default factory.
+- [ ] `subscribeRemoteOnly`, `subscribeForeign`, `replay` (ring buffer).
+- [ ] Telemetry hooks (`onCrossNodePublished` /
+      `onCrossNodeReceived` / `onCrossNodeError`).
+- [ ] `@furystack/cross-node-bus/testing` subpath with a two-instance
+      in-process harness.
+- [ ] Unit tests covering subscribe/publish, multiple subscribers,
+      disposal, originId, error isolation, replay window.
+
+### Milestone 2 — `IdentityEventBus` facade (rest-service)
+
+- [ ] Define event union + token + factory.
+- [ ] Wire `HttpUserContext.cookieLogout` to publish.
+- [ ] Subscribe in the factory; on `userLoggedOut` /
+      `sessionInvalidated` invalidate the local
+      `UserResolutionCache` entry.
+- [ ] Add `invalidateByUser(username)` to `UserResolutionCache`.
+- [ ] Multi-node integration test (≥ 2 in-process bus instances)
+      proving cross-node identity invalidation.
+- [ ] (Stretch) on `userLoggedOut`, walk the
+      `WebSocketApi.clients` map and close any sockets whose
+      `request.headers.cookie` carries the invalidated `sessionId`.
+
+### Milestone 3 — `EntityChangeBus` facade (entity-sync-service)
+
+- [ ] Define `EntityChangeBus` interface + token (depends on
+      `CrossNodeBus`).
+- [ ] Refactor `SubscriptionManager.registerModel` to publish +
+      subscribe via the broadcaster; single fan-out path.
+- [ ] Move sequence-number generation into the broadcaster;
+      in-process bus keeps a local counter.
+- [ ] Server-side seq dedup with TTL eviction.
+- [ ] Verify all existing tests pass — single-node story unchanged.
+- [ ] Multi-node integration test (≥ 2 in-process bus instances)
+      proving cross-node entity-change delivery and replay.
+
+### Milestone 4 — Redis Streams adapter
+
+- [ ] `@furystack/redis-cross-node-bus` package using Redis Streams
+      (`XADD` / `XREAD` consumer groups for per-node delivery).
+- [ ] Capability flags reflect persistence / replay / sequencing.
+- [ ] Adapter constructor accepts `{ url, topicPrefix, serviceName, replayWindow }`;
+      `nodeId` defaults to `${serviceName}-${random}`.
+- [ ] Integration tests gated on `docker-compose up redis` (existing
+      pattern).
+- [ ] Manual smoke-test harness with two Node processes against a
+      dockerized Redis verifies entity-sync + identity events
+      end-to-end.
+
+### Milestone 5 — Multi-service smoke test
+
+- [ ] Two services × two nodes each, single Redis, distinct
+      `topicPrefix` per service. Assertions:
+  - Identity events published by service A's auth path invalidate
+    caches on every node of service A and **only there**.
+  - Service B sees nothing on its own subscriptions.
+  - `subscribeForeign` from B to A's identity topic delivers
+    correctly when explicitly opted in.
+- [ ] All §4 success metrics measured and recorded.
+
+## 14. Risks & mitigations
+
+| Risk                                                                              | Severity | Mitigation                                                                                                                                       |
+| --------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Bus broker becomes a single point of failure                                      | high     | In-process adapter keeps working in degraded mode; `onCrossNodeError` telemetry alarms. Document SLO.                                            |
+| Cold-start ordering on `IdentityEventBus`                                         | low      | Bounded by `UserResolutionCache` TTL (default 30 s). Documented behavior; fix would cost adapter-agnosticism.                                    |
+| Schema-version skew during rolling deploys                                        | medium   | Dual-accept release cycle (§12). Pin window in release notes.                                                                                    |
+| `lastSeenSeq` map growth as nodes churn                                           | low      | TTL eviction after 1 h idle per `(topic, originId)`.                                                                                             |
+| Bursty models flooding the bus                                                    | medium   | Existing `debounceMs` / `queryTtlMs` knobs help. v1 commits to **coalesce-by-PK** semantics for any future per-model rate limit; **never drop**. |
+| Large entity payloads on broadcast                                                | medium   | v1 ships full-entity broadcast. v1.x will add an opt-in `broadcastPayload` hook on `DataSetSettings`; documented workaround in the meantime.     |
+| Capability mismatch between facade and adapter                                    | low      | Hard refusal at registration time; no silent degradation.                                                                                        |
+| Two `EntityChangeBus` consumers seeing different snapshots after partial delivery | medium   | Adapter-assigned seq + replay + server-side dedup converge state on next message.                                                                |
+
+## 15. Out of scope
+
+- **Distributed locks** for write coordination (writes still go through
   the underlying store).
-- Cross-node WebSocket handover ("clients on node A should keep their
-  subscriptions when A drains") — see Constraints; sticky load
-  balancing is the assumed deployment shape.
-- Auth-terminating gateway, signed identity headers between gateway
-  and services, per-request token exchange. Gateway MVP forwards
-  requests as-is and lets services own auth via the shared session
-  store.
-- Strongly-consistent state replication (this is a notification bus,
-  not a state machine — apps still own their persistent stores).
-- Discovery / membership / health (let the transport handle it; we
-  don't need to know which nodes are up).
-- Telemetry / metrics aggregation (handled by `ServerTelemetryToken`
-  consumers — Prometheus scrape, Datadog agent, etc.).
-- Application-level event sourcing (use a real event store like
-  EventStoreDB; this bus is for notifications, not the source of
-  truth).
+- **Cross-node WebSocket handover** ("clients on node A should keep
+  their subscriptions when A drains"). Sticky load balancing is the
+  assumed deployment shape for WS; HTTP traffic does **not** need to
+  be sticky. Brief disconnects + the existing initial-snapshot path
+  on reconnect cover state recovery.
+- **Public gateway, gateway routing, gateway-as-bus-consumer.** App
+  developers who need a gateway already implement specific solutions.
+  Not a framework concern at this layer.
+- **Auth-terminating gateway, signed identity headers, per-request
+  token exchange.** The shared session store + per-service auth model
+  already covers this.
+- **Strongly-consistent state replication.** This is a notification
+  bus, not a state machine — apps still own their persistent stores.
+- **Discovery / membership / health.** The transport handles it; we
+  don't need to know which nodes are up.
+- **Telemetry / metrics aggregation.** Handled by
+  `ServerTelemetryToken` consumers (Prometheus scrape, Datadog agent,
+  etc.).
+- **Application-level event sourcing.** Use a real event store
+  (EventStoreDB, etc.); this bus is for notifications, not the source
+  of truth.
+- **Distributed job/work queues.** `CrossNodeBus` is fan-out only:
+  every subscriber on every node receives every message. Competing-
+  consumer dispatch with ack / visibility-timeout / dead-letter
+  semantics is a different primitive. A future `@furystack/work-queue`
+  package could share the same adapter packages (Redis Streams
+  consumer groups, NATS JetStream pull consumers) but the API and
+  delivery semantics are not interchangeable. The bus **is** the
+  right tool for _broadcasting job status/progress and invalidating
+  cached job state_ alongside such a queue.
+- **Kafka adapter in v1.** Listed in §8 as a future option only.
 
-## Related work
+## 16. Open questions
 
-- PR #639 — captured-identity refactor in `SubscriptionManager`
+These are intentionally left for the implementer to settle during
+development; none of them gate the v1 plan.
+
+1. **Replay return type.** `replay(topic, fromSeq)` is specified as
+   `AsyncIterable<BusMessage>`. Confirm Redis Streams' streaming
+   semantics map cleanly; fall back to `Promise<BusMessage[]>` only
+   if backpressure becomes an issue.
+2. **`SubscriptionManager` exports.** Whether the refactor is a major
+   or minor bump for `@furystack/entity-sync-service` depends on
+   what `index.ts` re-exports — confirm during Milestone 3.
+3. **In-process adapter ring-buffer eviction behavior on burst.** When
+   a single topic exceeds 1 000 messages within the replay window,
+   does the broadcaster surface a metric so operators tune up the
+   window?
+4. **Foreign-prefix subscribe authorization.** Should the Redis
+   adapter guard `subscribeForeign` behind an explicit allow-list
+   in adapter config, or trust the developer's intent?
+
+## 17. Dependencies & related work
+
+- **PR #639** — captured-identity refactor in `SubscriptionManager`
   (prerequisite: subscriptions must not retain the per-message
-  websocket scope, so cross-node delivery on a captured-identity scope
-  is well-defined).
-- `feat/huc-ttl-cache` (in flight at the time of writing) — short-TTL
-  user-resolution cache in `@furystack/rest-service`. Bounds
-  cross-instance staleness for session/role changes; this spike
-  collapses that window further for the events where sub-TTL latency
-  matters.
-- `docs/internal/functional-di-migration-plan.md` — established the
-  "interface + token + factory" pattern this spike follows for the
-  `CrossNodeBus` token and every facade.
+  WebSocket scope, so cross-node delivery on a captured-identity
+  scope is well-defined). Status to be confirmed at Milestone 3 kickoff.
+- **`feat/huc-ttl-cache`** — short-TTL user-resolution cache in
+  `@furystack/rest-service`. Bounds cross-instance staleness for
+  session/role changes; this PRD collapses that window further for
+  the events where sub-TTL latency matters.
+- **`docs/internal/functional-di-migration-plan.md`** — established
+  the "interface + token + factory" pattern this PRD follows for
+  the `CrossNodeBus` token, every facade, and every adapter
+  helper.
+- **`@furystack/utils` `EventHub<T>`** — facades compose an internal
+  `EventHub` for typed local dispatch and listener error isolation.
+  Internal `ListenerRegistry` extraction is optional; the
+  `InProcessCrossNodeBus` may reuse `EventHub` directly if the
+  duplication stays under ~30 LOC.

--- a/docs/internal/cross-node-bus-spike.md
+++ b/docs/internal/cross-node-bus-spike.md
@@ -739,12 +739,12 @@ state.
       internal `Cache` generic from `Cache<User, [string]>` to
       `Cache<User, [string], \`user:${string}\`>` for typed-tag safety
       and add `getTags: (user) => [\`user:${user.username}\`]`to
-    the constructor. Expose`invalidateByUser(username)`on the
-   `UserResolutionCache`interface, backed by
-   `cache.removeByTag(\`user:${username}\`)`. Useful in single-node
-    deployments today (apps currently have no per-user
-    invalidation short of `invalidateAll`) and is the hook
-    `IdentityEventBus` consumes in Milestone 2.
+ the constructor. Expose`invalidateByUser(username)`on the
+`UserResolutionCache`interface, backed by
+`cache.removeByTag(\`user:${username}\`)`. Useful in single-node
+ deployments today (apps currently have no per-user
+ invalidation short of `invalidateAll`) and is the hook
+ `IdentityEventBus` consumes in Milestone 2.
 - [ ] **M0.2 — Centralize identity cache-key / tag shape.** Extract
       the `cookie:${sessionId}` cache-key template and the
       `user:${username}` tag template into a small shared helpers

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -60,13 +60,32 @@ await cache.get(1, 2) // 3 will be calculated and cached
 cache.remove(1, 2) // Removes the specific cached item
 const result = await cache.get(1, 2) // Recalculates: 3
 
-// Remove specific range, where the sum is 3 or the arguments are as specified
-cache.removeRange((entity, args) => {
-  return entity === 3 || (args[0] === 1 && args[1] === 3)
-})
-
 cache.flushAll() // Removes all cached items
 ```
+
+### Tag-based invalidation
+
+`getTags` attaches a set of plain string tags to each entry whenever it transitions to a `loaded` state. `obsoleteByTag` and `removeByTag` then act on every entry currently bound to that tag. Tags are deliberately serializable so the same invalidation can be replicated over a cross-process bus.
+
+```ts
+import { Cache } from '@furystack/cache'
+
+type User = { username: string; tenant: string }
+type UserCacheTag = `tenant:${string}` | `user:${string}`
+
+const cache = new Cache<User, [string], UserCacheTag>({
+  load: (sessionId) => resolveSession(sessionId),
+  getKey: (sessionId) => `cookie:${sessionId}`,
+  getTags: (user) => [`tenant:${user.tenant}`, `user:${user.username}`],
+})
+
+await cache.get('session-abc')
+
+cache.obsoleteByTag('user:alice') // mark loaded entries stale
+cache.removeByTag('tenant:acme') // drop every entry for a tenant
+```
+
+`getTags` receives the loaded value and the originating args, so tags can incorporate state that lives only on the value side. Tags persist across `loading` / `failed` / `obsolete` transitions until the next successful load recomputes them.
 
 ### Subscribe to Changes
 

--- a/packages/cache/src/cache-state-manager.ts
+++ b/packages/cache/src/cache-state-manager.ts
@@ -22,14 +22,14 @@ export class CannotObsoleteUnloadedError<T> extends Error {
 interface CacheStoreEntry<T, TArgs extends any[]> {
   observable: ObservableValue<CacheResult<T>>
   args: TArgs
+  tags: Set<string>
 }
 
 /**
  * Low-level storage primitive used by {@link Cache}. Tracks per-key
  * `ObservableValue<CacheResult<T>>` plus the most recent `args` that
- * produced it, so range predicates (`obsoleteRange` / `removeRange`)
- * receive the actual call args even when {@link Cache} uses a custom
- * `getKey` resolver.
+ * produced it and an optional set of tags derived from the loaded
+ * value (see {@link Cache.obsoleteByTag} / {@link Cache.removeByTag}).
  *
  * **Not part of the public API.** Method signatures may change without
  * a major version bump. Use {@link Cache} from `@furystack/cache`
@@ -41,9 +41,12 @@ interface CacheStoreEntry<T, TArgs extends any[]> {
 export class CacheStateManager<T, TArgs extends any[]> implements Disposable {
   private readonly store = new Map<string, CacheStoreEntry<T, TArgs>>()
 
+  private readonly tagIndex = new Map<string, Set<string>>()
+
   public [Symbol.dispose]() {
     ;[...this.store.values()].forEach((entry) => entry.observable[Symbol.dispose]())
     this.store.clear()
+    this.tagIndex.clear()
   }
 
   public has(index: string) {
@@ -61,11 +64,16 @@ export class CacheStateManager<T, TArgs extends any[]> implements Disposable {
       existing.args = args
       this.store.set(key, existing)
     } else {
-      this.store.set(key, { observable: new ObservableValue<CacheResult<T>>(initialState), args })
+      this.store.set(key, {
+        observable: new ObservableValue<CacheResult<T>>(initialState),
+        args,
+        tags: new Set<string>(),
+      })
     }
 
     if (this.store.size > (this.options.capacity || Infinity)) {
       const [firstKey] = this.store.keys()
+      this.dropTagsForKey(firstKey)
       this.store.get(firstKey)?.observable[Symbol.dispose]()
       this.store.delete(firstKey)
     }
@@ -77,17 +85,20 @@ export class CacheStateManager<T, TArgs extends any[]> implements Disposable {
     return this.store.get(key)?.observable.getValue().value
   }
 
-  public setValue(key: string, args: TArgs, value: CacheResult<T>) {
+  public setValue(key: string, args: TArgs, value: CacheResult<T>, tags?: readonly string[]) {
     this.getObservable(key, args).setValue(value)
+    if (tags !== undefined) {
+      this.updateTagsForKey(key, tags)
+    }
   }
 
   public setLoadingState(key: string, args: TArgs) {
     this.setValue(key, args, { status: 'loading', value: this.peekValue(key), updatedAt: new Date() })
   }
 
-  public setLoadedState(key: string, args: TArgs, value: T) {
+  public setLoadedState(key: string, args: TArgs, value: T, tags?: readonly string[]) {
     const newValue: LoadedCacheResult<T> = { status: 'loaded', value, updatedAt: new Date() }
-    this.setValue(key, args, newValue)
+    this.setValue(key, args, newValue, tags)
     return newValue
   }
 
@@ -106,7 +117,7 @@ export class CacheStateManager<T, TArgs extends any[]> implements Disposable {
     const currentValue = this.getObservable(key, args).getValue()
 
     if (isObsoleteCacheResult(currentValue)) {
-      return currentValue // Already obsolete
+      return currentValue
     }
 
     if (isLoadedCacheResult(currentValue)) {
@@ -125,6 +136,7 @@ export class CacheStateManager<T, TArgs extends any[]> implements Disposable {
   public remove(key: string) {
     const existing = this.store.get(key)
     if (existing) {
+      this.dropTagsForKey(key)
       existing.observable[Symbol.dispose]()
     }
     return this.store.delete(key)
@@ -133,30 +145,91 @@ export class CacheStateManager<T, TArgs extends any[]> implements Disposable {
   public flushAll() {
     this.store.forEach((entry) => entry.observable[Symbol.dispose]())
     this.store.clear()
+    this.tagIndex.clear()
   }
 
-  public obsoleteRange(predicate: (value: T, args: TArgs) => boolean) {
-    ;[...this.store.entries()].forEach(([key, { observable, args }]) => {
-      const currentState = observable.getValue()
-      if (!isLoadedCacheResult(currentState)) {
-        return
+  /**
+   * Transitions every `loaded` entry tagged with `tag` to `obsolete`.
+   * Entries in other states are skipped. Returns the count of entries
+   * actually transitioned.
+   */
+  public obsoleteByTag(tag: string): number {
+    const keys = this.tagIndex.get(tag)
+    if (!keys || keys.size === 0) return 0
+    let count = 0
+    for (const key of [...keys]) {
+      const entry = this.store.get(key)
+      if (!entry) continue
+      const current = entry.observable.getValue()
+      if (isLoadedCacheResult(current)) {
+        this.setObsoleteState(key, entry.args)
+        count++
       }
-      if (predicate(currentState.value, args)) {
-        this.setObsoleteState(key, args)
-      }
-    })
+    }
+    return count
   }
 
-  public removeRange(predicate: (value: T, args: TArgs) => boolean) {
-    ;[...this.store.entries()].forEach(([key, { observable, args }]) => {
-      const currentState = observable.getValue()
-      if (!isLoadedCacheResult(currentState)) {
-        return
+  /**
+   * Removes every entry tagged with `tag` regardless of state. Returns
+   * the keys of removed entries so the {@link Cache} wrapper can clear
+   * any per-key timers it owns.
+   */
+  public removeByTag(tag: string): string[] {
+    const keys = this.tagIndex.get(tag)
+    if (!keys || keys.size === 0) return []
+    const removed: string[] = []
+    for (const key of [...keys]) {
+      if (this.remove(key)) {
+        removed.push(key)
       }
-      if (predicate(currentState.value, args)) {
-        this.remove(key)
+    }
+    return removed
+  }
+
+  private updateTagsForKey(key: string, nextTags: readonly string[]) {
+    const entry = this.store.get(key)
+    if (!entry) return
+    const dedupedNext = new Set<string>(nextTags)
+
+    for (const tag of entry.tags) {
+      if (!dedupedNext.has(tag)) {
+        const set = this.tagIndex.get(tag)
+        if (set) {
+          set.delete(key)
+          if (set.size === 0) {
+            this.tagIndex.delete(tag)
+          }
+        }
       }
-    })
+    }
+
+    for (const tag of dedupedNext) {
+      if (!entry.tags.has(tag)) {
+        let set = this.tagIndex.get(tag)
+        if (!set) {
+          set = new Set<string>()
+          this.tagIndex.set(tag, set)
+        }
+        set.add(key)
+      }
+    }
+
+    entry.tags = dedupedNext
+  }
+
+  private dropTagsForKey(key: string) {
+    const entry = this.store.get(key)
+    if (!entry) return
+    for (const tag of entry.tags) {
+      const set = this.tagIndex.get(tag)
+      if (set) {
+        set.delete(key)
+        if (set.size === 0) {
+          this.tagIndex.delete(tag)
+        }
+      }
+    }
+    entry.tags.clear()
   }
 
   constructor(private readonly options: CacheStateManagerOptions) {}

--- a/packages/cache/src/cache.spec.ts
+++ b/packages/cache/src/cache.spec.ts
@@ -491,7 +491,40 @@ describe('Cache', () => {
       })
     })
 
-    it('removeByTag removes every tagged entry regardless of state and clears timers', async () => {
+    it('Tags persist across a loaded → failed transition so removeByTag still matches', async () => {
+      let shouldFail = false
+      const load = vi.fn(async () => {
+        if (shouldFail) {
+          throw new Error('boom')
+        }
+        return { username: 'alice', tenant: 'acme' }
+      })
+      await usingAsync(makeUserCache(load), async (cache) => {
+        await cache.get('s-1')
+        shouldFail = true
+        await expect(cache.reload('s-1')).rejects.toThrow('boom')
+        expect(cache.getObservable('s-1').getValue().status).toEqual('failed')
+
+        expect(cache.obsoleteByTag('user:alice')).toEqual(0)
+        expect(cache.removeByTag('user:alice')).toEqual(1)
+        expect(cache.has('s-1')).toBe(false)
+      })
+    })
+
+    it('Tags persist across a loaded → obsolete transition so removeByTag still matches', async () => {
+      const load = vi.fn(async () => ({ username: 'alice', tenant: 'acme' }))
+      await usingAsync(makeUserCache(load), async (cache) => {
+        await cache.get('s-1')
+        cache.setObsolete('s-1')
+        expect(cache.getObservable('s-1').getValue().status).toEqual('obsolete')
+
+        expect(cache.obsoleteByTag('user:alice')).toEqual(0)
+        expect(cache.removeByTag('user:alice')).toEqual(1)
+        expect(cache.has('s-1')).toBe(false)
+      })
+    })
+
+    it('removeByTag removes every tagged entry regardless of state and clears pending stale timers', async () => {
       const load = vi.fn(async (sessionId: string) => ({
         username: sessionId === 's-2' ? 'bob' : 'alice',
         tenant: 'acme',
@@ -501,7 +534,7 @@ describe('Cache', () => {
           load,
           getKey: (sessionId) => `cookie:${sessionId}`,
           getTags: (user) => [`tenant:${user.tenant}`, `user:${user.username}`],
-          cacheTimeMs: 1000,
+          staleTimeMs: 1000,
         }),
         async (cache) => {
           await cache.get('s-1')
@@ -516,6 +549,7 @@ describe('Cache', () => {
           await vi.advanceTimersByTimeAsync(2000)
           expect(cache.has('s-1')).toBe(false)
           expect(cache.has('s-2')).toBe(false)
+          expect(cache.getCount()).toEqual(0)
         },
       )
     })

--- a/packages/cache/src/cache.spec.ts
+++ b/packages/cache/src/cache.spec.ts
@@ -155,52 +155,6 @@ describe('Cache', () => {
     })
   })
 
-  it('Should remove a value from the cache, based on a predicate', async () => {
-    await usingAsync(new Cache({ load: (a: number, b: number) => Promise.resolve(a + b) }), async (cache) => {
-      await cache.get(1, 2)
-      await cache.get(1, 3)
-      expect(cache.getCount()).toEqual(2)
-      cache.removeRange((v) => v === 3)
-      expect(cache.getCount()).toEqual(1)
-    })
-  })
-
-  it('Should skip entries in loading state when calling removeRange', async () => {
-    const loader = vi.fn((a: number, b: number) => Promise.resolve(a + b))
-
-    await usingAsync(new Cache({ load: loader }), async (cache) => {
-      await cache.get(1, 2)
-      cache.setExplicitValue({
-        loadArgs: [3, 4],
-        value: { status: 'loading', value: 7, updatedAt: new Date() },
-      })
-      expect(cache.getCount()).toEqual(2)
-
-      cache.removeRange(() => true)
-
-      expect(cache.getCount()).toEqual(1)
-      expect(cache.has(3, 4)).toEqual(true)
-    })
-  })
-
-  it('Should skip entries in failed state when calling removeRange', async () => {
-    const loader = vi.fn((a: number, b: number) => Promise.resolve(a + b))
-
-    await usingAsync(new Cache({ load: loader }), async (cache) => {
-      await cache.get(1, 2)
-      cache.setExplicitValue({
-        loadArgs: [3, 4],
-        value: { status: 'failed', error: new Error('fail'), value: 7, updatedAt: new Date() },
-      })
-      expect(cache.getCount()).toEqual(2)
-
-      cache.removeRange(() => true)
-
-      expect(cache.getCount()).toEqual(1)
-      expect(cache.has(3, 4)).toEqual(true)
-    })
-  })
-
   it('Should remove all values from the cache', async () => {
     await usingAsync(new Cache({ load: (a: number, b: number) => Promise.resolve(a + b) }), async (cache) => {
       await cache.get(1, 2)
@@ -377,62 +331,6 @@ describe('Cache', () => {
         expect(() => cache.setObsolete(1, 2)).toThrow()
       })
     })
-
-    it('Should set an obsolete state based on a predicate', async () => {
-      const loader = vi.fn((a: number, b: number) => Promise.resolve(a + b))
-
-      await usingAsync(new Cache({ load: loader }), async (cache) => {
-        const result = await cache.get(1, 2)
-        expect(result).toEqual(3)
-
-        cache.obsoleteRange((v) => v === 3)
-
-        const result2 = await cache.get(1, 2)
-        expect(result2).toEqual(3)
-
-        expect(loader).toHaveBeenCalledTimes(2)
-      })
-    })
-
-    it('Should skip entries in loading state when calling obsoleteRange', async () => {
-      const loader = vi.fn((a: number, b: number) => Promise.resolve(a + b))
-
-      await usingAsync(new Cache({ load: loader }), async (cache) => {
-        await cache.get(1, 2)
-        cache.setExplicitValue({
-          loadArgs: [3, 4],
-          value: { status: 'loading', value: 7, updatedAt: new Date() },
-        })
-
-        expect(() => cache.obsoleteRange(() => true)).not.toThrow()
-
-        const loadedEntry = cache.getObservable(1, 2).getValue()
-        expect(loadedEntry.status).toEqual('obsolete')
-
-        const loadingEntry = cache.getObservable(3, 4).getValue()
-        expect(loadingEntry.status).toEqual('loading')
-      })
-    })
-
-    it('Should skip entries in failed state when calling obsoleteRange', async () => {
-      const loader = vi.fn((a: number, b: number) => Promise.resolve(a + b))
-
-      await usingAsync(new Cache({ load: loader }), async (cache) => {
-        await cache.get(1, 2)
-        cache.setExplicitValue({
-          loadArgs: [3, 4],
-          value: { status: 'failed', error: new Error('fail'), value: 7, updatedAt: new Date() },
-        })
-
-        expect(() => cache.obsoleteRange(() => true)).not.toThrow()
-
-        const loadedEntry = cache.getObservable(1, 2).getValue()
-        expect(loadedEntry.status).toEqual('obsolete')
-
-        const failedEntry = cache.getObservable(3, 4).getValue()
-        expect(failedEntry.status).toEqual('failed')
-      })
-    })
   })
 
   describe('Error state', () => {
@@ -523,39 +421,224 @@ describe('Cache', () => {
         },
       )
     })
+  })
 
-    it('Should expose the original args in obsoleteRange / removeRange predicates with a custom getKey', async () => {
-      type Payload = { tenant: string; ignored: object }
-      const loader = vi.fn((p: Payload) => Promise.resolve(`loaded-${p.tenant}`))
+  describe('Tag-based invalidation', () => {
+    type TenantUser = { username: string; tenant: string }
+    type UserCacheTag = `tenant:${string}` | `user:${string}`
+
+    const makeUserCache = (
+      load: (sessionId: string) => Promise<TenantUser>,
+      capacity?: number,
+    ): Cache<TenantUser, [string], UserCacheTag> =>
+      new Cache<TenantUser, [string], UserCacheTag>({
+        load,
+        getKey: (sessionId) => `cookie:${sessionId}`,
+        getTags: (user) => [`tenant:${user.tenant}`, `user:${user.username}`],
+        capacity,
+      })
+
+    it('obsoleteByTag transitions every loaded entry tagged with the supplied tag', async () => {
+      const load = vi.fn(async (sessionId: string) => ({
+        username: sessionId === 's-2' ? 'bob' : 'alice',
+        tenant: 'acme',
+      }))
+      await usingAsync(makeUserCache(load), async (cache) => {
+        await cache.get('s-1')
+        await cache.get('s-2')
+
+        const affected = cache.obsoleteByTag('tenant:acme')
+
+        expect(affected).toEqual(2)
+        expect(cache.getObservable('s-1').getValue().status).toEqual('obsolete')
+        expect(cache.getObservable('s-2').getValue().status).toEqual('obsolete')
+      })
+    })
+
+    it('obsoleteByTag returns 0 and is a no-op when the tag is unknown', async () => {
+      const load = vi.fn(async () => ({ username: 'alice', tenant: 'acme' }))
+      await usingAsync(makeUserCache(load), async (cache) => {
+        await cache.get('s-1')
+
+        const affected = cache.obsoleteByTag('user:nobody')
+
+        expect(affected).toEqual(0)
+        expect(cache.getObservable('s-1').getValue().status).toEqual('loaded')
+      })
+    })
+
+    it('obsoleteByTag skips entries in loading / failed / obsolete states', async () => {
+      const load = vi.fn(async () => ({ username: 'alice', tenant: 'acme' }))
+      await usingAsync(makeUserCache(load), async (cache) => {
+        await cache.get('s-loaded')
+
+        cache.setExplicitValue({
+          loadArgs: ['s-failed'],
+          value: {
+            status: 'failed',
+            error: new Error('boom'),
+            value: { username: 'alice', tenant: 'acme' },
+            updatedAt: new Date(),
+          },
+        })
+
+        await cache.get('s-obsolete')
+        cache.setObsolete('s-obsolete')
+
+        expect(cache.obsoleteByTag('user:alice')).toEqual(1)
+        expect(cache.getObservable('s-loaded').getValue().status).toEqual('obsolete')
+        expect(cache.getObservable('s-failed').getValue().status).toEqual('failed')
+      })
+    })
+
+    it('removeByTag removes every tagged entry regardless of state and clears timers', async () => {
+      const load = vi.fn(async (sessionId: string) => ({
+        username: sessionId === 's-2' ? 'bob' : 'alice',
+        tenant: 'acme',
+      }))
       await usingAsync(
-        new Cache<string, [Payload]>({
-          load: loader,
-          getKey: (p) => p.tenant,
+        new Cache<TenantUser, [string], UserCacheTag>({
+          load,
+          getKey: (sessionId) => `cookie:${sessionId}`,
+          getTags: (user) => [`tenant:${user.tenant}`, `user:${user.username}`],
+          cacheTimeMs: 1000,
         }),
         async (cache) => {
-          await cache.get({ tenant: 'a', ignored: {} })
-          await cache.get({ tenant: 'b', ignored: {} })
+          await cache.get('s-1')
+          await cache.get('s-2')
 
-          const seenObsoleteArgs: Payload[] = []
-          cache.obsoleteRange((_value, [args]) => {
-            seenObsoleteArgs.push(args)
-            return args.tenant === 'a'
-          })
-          expect(seenObsoleteArgs.map((a) => a.tenant).sort()).toEqual(['a', 'b'])
-          expect(cache.getObservable({ tenant: 'a', ignored: {} }).getValue().status).toEqual('obsolete')
-          expect(cache.getObservable({ tenant: 'b', ignored: {} }).getValue().status).toEqual('loaded')
+          const removed = cache.removeByTag('tenant:acme')
 
-          await cache.get({ tenant: 'a', ignored: {} })
-          const seenRemoveArgs: Payload[] = []
-          cache.removeRange((_value, [args]) => {
-            seenRemoveArgs.push(args)
-            return args.tenant === 'b'
-          })
-          expect(seenRemoveArgs.map((a) => a.tenant).sort()).toEqual(['a', 'b'])
-          expect(cache.has({ tenant: 'a', ignored: {} })).toBe(true)
-          expect(cache.has({ tenant: 'b', ignored: {} })).toBe(false)
+          expect(removed).toEqual(2)
+          expect(cache.has('s-1')).toBe(false)
+          expect(cache.has('s-2')).toBe(false)
+
+          await vi.advanceTimersByTimeAsync(2000)
+          expect(cache.has('s-1')).toBe(false)
+          expect(cache.has('s-2')).toBe(false)
         },
       )
+    })
+
+    it('removeByTag returns 0 when the tag is unknown', async () => {
+      const load = vi.fn(async () => ({ username: 'alice', tenant: 'acme' }))
+      await usingAsync(makeUserCache(load), async (cache) => {
+        await cache.get('s-1')
+
+        expect(cache.removeByTag('tenant:other')).toEqual(0)
+        expect(cache.has('s-1')).toBe(true)
+      })
+    })
+
+    it('Tag index reflects diffs when an entry is reloaded with a different tag set', async () => {
+      let username = 'alice'
+      const load = vi.fn(async () => ({ username, tenant: 'acme' }))
+      await usingAsync(makeUserCache(load), async (cache) => {
+        await cache.get('s-1')
+        expect(cache.obsoleteByTag('user:alice')).toEqual(1)
+
+        await cache.get('s-1')
+        username = 'alice-renamed'
+        await cache.reload('s-1')
+
+        expect(cache.obsoleteByTag('user:alice')).toEqual(0)
+        expect(cache.obsoleteByTag('user:alice-renamed')).toEqual(1)
+      })
+    })
+
+    it('LRU eviction drops evicted keys from the tag index', async () => {
+      const load = vi.fn(async (sessionId: string) => ({ username: sessionId, tenant: 'acme' }))
+      await usingAsync(makeUserCache(load, 2), async (cache) => {
+        await cache.get('s-1')
+        await cache.get('s-2')
+        await cache.get('s-3')
+
+        expect(cache.removeByTag('user:s-1')).toEqual(0)
+        expect(cache.obsoleteByTag('tenant:acme')).toEqual(2)
+      })
+    })
+
+    it('flushAll clears the tag index', async () => {
+      const load = vi.fn(async () => ({ username: 'alice', tenant: 'acme' }))
+      await usingAsync(makeUserCache(load), async (cache) => {
+        await cache.get('s-1')
+        cache.flushAll()
+
+        expect(cache.removeByTag('tenant:acme')).toEqual(0)
+        expect(cache.obsoleteByTag('user:alice')).toEqual(0)
+      })
+    })
+
+    it('Duplicate tags returned by getTags are deduplicated', async () => {
+      const load = vi.fn(async (sessionId: string) => ({ username: sessionId, tenant: 'acme' }))
+      await usingAsync(
+        new Cache<TenantUser, [string], 'dup'>({
+          load,
+          getKey: (sessionId) => sessionId,
+          getTags: () => ['dup', 'dup', 'dup'],
+        }),
+        async (cache) => {
+          await cache.get('s-1')
+          expect(cache.removeByTag('dup')).toEqual(1)
+        },
+      )
+    })
+
+    it('Empty tags array leaves an entry unmatched by any tag', async () => {
+      const load = vi.fn(async (sessionId: string) => ({ username: sessionId, tenant: 'acme' }))
+      await usingAsync(
+        new Cache<TenantUser, [string], string>({
+          load,
+          getKey: (sessionId) => sessionId,
+          getTags: () => [],
+        }),
+        async (cache) => {
+          await cache.get('s-1')
+          expect(cache.obsoleteByTag('anything')).toEqual(0)
+          expect(cache.removeByTag('anything')).toEqual(0)
+          expect(cache.has('s-1')).toBe(true)
+        },
+      )
+    })
+
+    it('No-ops when getTags is not configured', async () => {
+      const load = vi.fn((a: number, b: number) => Promise.resolve(a + b))
+      await usingAsync(new Cache({ load }), async (cache) => {
+        await cache.get(1, 2)
+        expect(cache.obsoleteByTag('whatever')).toEqual(0)
+        expect(cache.removeByTag('whatever')).toEqual(0)
+        expect(cache.has(1, 2)).toBe(true)
+      })
+    })
+
+    it('setExplicitValue with a loaded value computes tags', async () => {
+      const load = vi.fn(async () => ({ username: 'alice', tenant: 'acme' }))
+      await usingAsync(makeUserCache(load), async (cache) => {
+        cache.setExplicitValue({
+          loadArgs: ['s-1'],
+          value: {
+            status: 'loaded',
+            value: { username: 'alice', tenant: 'acme' },
+            updatedAt: new Date(),
+          },
+        })
+
+        expect(cache.removeByTag('user:alice')).toEqual(1)
+      })
+    })
+
+    it('setExplicitValue with a non-loaded value does not register tags', async () => {
+      const load = vi.fn(async () => ({ username: 'alice', tenant: 'acme' }))
+      await usingAsync(makeUserCache(load), async (cache) => {
+        cache.setExplicitValue({
+          loadArgs: ['s-1'],
+          value: { status: 'failed', error: new Error('boom'), updatedAt: new Date() },
+        })
+
+        expect(cache.removeByTag('user:alice')).toEqual(0)
+        expect(cache.removeByTag('tenant:acme')).toEqual(0)
+        expect(cache.has('s-1')).toBe(true)
+      })
     })
   })
 

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -218,11 +218,11 @@ export class Cache<TData, TArgs extends any[], TTag extends string = string>
    */
   public setExplicitValue({ loadArgs, value }: { loadArgs: TArgs; value: CacheResult<TData> }) {
     const index = this.getIndex(...loadArgs)
-    if (isLoadedCacheResult(value)) {
-      this.stateManager.setValue(index, loadArgs, value, this.resolveTags(value.value, loadArgs))
+    const isLoaded = isLoadedCacheResult(value)
+    const tags = isLoaded ? this.resolveTags(value.value, loadArgs) : undefined
+    this.stateManager.setValue(index, loadArgs, value, tags)
+    if (isLoaded) {
       this.setupTimers(index, loadArgs)
-    } else {
-      this.stateManager.setValue(index, loadArgs, value)
     }
   }
 

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -3,7 +3,7 @@ import type { CacheResult } from './cache-result.js'
 import { isLoadedCacheResult } from './cache-result.js'
 import { CacheStateManager, CannotObsoleteUnloadedError } from './cache-state-manager.js'
 
-export interface CacheSettings<TData, TArgs extends any[]> {
+export interface CacheSettings<TData, TArgs extends any[], TTag extends string = string> {
   /** Loader invoked on cache miss. Concurrent calls for the same key are deduplicated. */
   load: (...args: TArgs) => Promise<TData>
 
@@ -21,37 +21,64 @@ export interface CacheSettings<TData, TArgs extends any[]> {
    * sufficient for primitives + plain objects, unusable for non-serializable
    * args (e.g. `IncomingMessage`). Override when only a subset of the args
    * should participate in cache lookup.
-   *
-   * **Note:** the predicates passed to {@link Cache.obsoleteRange} and
-   * {@link Cache.removeRange} receive the `args` reference from the most
-   * recent `get` / `reload` / `setExplicitValue` call for that entry. Do
-   * not mutate the args object after caching; clone if you need a snapshot.
    */
   getKey?: (...args: TArgs) => string
+
+  /**
+   * Resolver for the set of tags attached to an entry whenever it
+   * transitions to a `'loaded'` state (via successful `load` / `reload`
+   * or {@link Cache.setExplicitValue} with a loaded value). Tags drive
+   * {@link Cache.obsoleteByTag} and {@link Cache.removeByTag}, designed
+   * to be serializable so a remote node on a cross-process bus can
+   * reproduce the same invalidation by emitting the tag string.
+   *
+   * Receives both the loaded `value` and the originating `args`, so
+   * tags can incorporate state that lives only on the value side
+   * (e.g. the `username` extracted from a session-keyed identity).
+   *
+   * Tags are recomputed on every successful load and do not change
+   * while an entry is in `loading` / `failed` / `obsolete` — the last
+   * loaded value's tags persist, so `removeByTag` still matches an
+   * entry that has since been marked obsolete.
+   */
+  getTags?: (value: TData, ...args: TArgs) => readonly TTag[]
 }
 
 /**
  * Async loader cache with state-machine semantics ({@link CacheResult}),
- * concurrent-load deduplication, optional LRU capacity, and stale + cache
- * TTL timers. Extends {@link EventHub} with `onLoadError` and emits the
- * inherited `onListenerError`.
+ * concurrent-load deduplication, optional LRU capacity, stale + cache
+ * TTL timers, and serializable tag-based invalidation. Extends
+ * {@link EventHub} with `onLoadError` and emits the inherited
+ * `onListenerError`.
  *
  * @example
  * ```ts
- * using(new Cache({ load: (id: string) => fetchUser(id), staleTimeMs: 30_000 }), (cache) => {
- *   const obs = cache.getObservable('alice')
- *   obs.subscribe((state) => render(state))
- * })
+ * type SessionCacheTag = `user:${string}`
+ *
+ * using(
+ *   new Cache<User, [string], SessionCacheTag>({
+ *     load: (sessionId: string) => resolveSession(sessionId),
+ *     getKey: (sessionId) => `cookie:${sessionId}`,
+ *     getTags: (user) => [`user:${user.username}`],
+ *     staleTimeMs: 30_000,
+ *   }),
+ *   (cache) => {
+ *     const obs = cache.getObservable('abc')
+ *     obs.subscribe((state) => render(state))
+ *     // Later, e.g. on password change:
+ *     cache.removeByTag('user:alice')
+ *   },
+ * )
  * ```
  */
-export class Cache<TData, TArgs extends any[]>
+export class Cache<TData, TArgs extends any[], TTag extends string = string>
   extends EventHub<{
     onLoadError: { args: TArgs; error: unknown }
     onListenerError: ListenerErrorPayload
   }>
   implements Disposable
 {
-  constructor(private readonly options: CacheSettings<TData, TArgs>) {
+  constructor(private readonly options: CacheSettings<TData, TArgs, TTag>) {
     super()
     this.stateManager = new CacheStateManager<TData, TArgs>({ capacity: this.options.capacity })
   }
@@ -73,6 +100,11 @@ export class Cache<TData, TArgs extends any[]>
   }
 
   private getIndex = (...args: TArgs) => (this.options.getKey ? this.options.getKey(...args) : JSON.stringify(args))
+
+  private resolveTags(value: TData, args: TArgs): readonly string[] | undefined {
+    if (!this.options.getTags) return undefined
+    return this.options.getTags(value, ...args)
+  }
 
   private readonly stateManager: CacheStateManager<TData, TArgs>
 
@@ -156,7 +188,7 @@ export class Cache<TData, TArgs extends any[]>
     try {
       this.stateManager.setLoadingState(index, args)
       const loaded = await this.options.load(...args)
-      this.stateManager.setLoadedState(index, args, loaded)
+      this.stateManager.setLoadedState(index, args, loaded, this.resolveTags(loaded, args))
       this.setupTimers(index, args)
       return loaded
     } catch (error) {
@@ -180,15 +212,17 @@ export class Cache<TData, TArgs extends any[]>
   /**
    * Writes `value` directly into the entry for `loadArgs`, bypassing
    * {@link CacheSettings.load}. When `value.status === 'loaded'` the stale
-   * and cache TTL timers are (re-)armed — same as a successful
-   * {@link Cache.get} / {@link Cache.reload}. Other statuses leave timers
+   * and cache TTL timers are (re-)armed and tags are recomputed via
+   * {@link CacheSettings.getTags}. Other statuses leave timers and tags
    * untouched.
    */
   public setExplicitValue({ loadArgs, value }: { loadArgs: TArgs; value: CacheResult<TData> }) {
     const index = this.getIndex(...loadArgs)
-    this.stateManager.setValue(index, loadArgs, value)
     if (isLoadedCacheResult(value)) {
+      this.stateManager.setValue(index, loadArgs, value, this.resolveTags(value.value, loadArgs))
       this.setupTimers(index, loadArgs)
+    } else {
+      this.stateManager.setValue(index, loadArgs, value)
     }
   }
 
@@ -230,19 +264,26 @@ export class Cache<TData, TArgs extends any[]>
   }
 
   /**
-   * Marks every `'loaded'` entry whose `(value, args)` satisfy `callback`
-   * as `'obsolete'`. Entries in other states are skipped. The `args` passed
-   * to `callback` are the ones recorded by the most recent `get` / `reload`
-   * / `setExplicitValue` for that entry — see {@link CacheSettings.getKey}
-   * for the no-mutate constraint.
+   * Transitions every `'loaded'` entry currently tagged with `tag` to
+   * `'obsolete'`. Entries in other states are skipped. Returns the
+   * number of entries actually transitioned. The `tag` is a plain
+   * string — designed for replication over a serializable bus.
    */
-  public obsoleteRange(callback: (entity: TData, args: TArgs) => boolean) {
-    this.stateManager.obsoleteRange(callback)
+  public obsoleteByTag(tag: TTag): number {
+    return this.stateManager.obsoleteByTag(tag)
   }
 
-  /** {@link Cache.obsoleteRange} for removal. Same iteration + args contract. */
-  public removeRange(callback: (entity: TData, args: TArgs) => boolean) {
-    this.stateManager.removeRange(callback)
+  /**
+   * Removes every entry currently tagged with `tag` regardless of
+   * state and clears any pending stale / cache TTL timers for those
+   * entries. Returns the number of entries removed.
+   */
+  public removeByTag(tag: TTag): number {
+    const removedKeys = this.stateManager.removeByTag(tag)
+    for (const key of removedKeys) {
+      this.clearTimers(key)
+    }
+    return removedKeys.length
   }
 
   public flushAll() {


### PR DESCRIPTION
## 🎯 Summary

Replaces the predicate-based range invalidation APIs on `Cache` with a
serializable, tag-based invalidation scheme designed to be replayed across
processes over a future cross-node event bus. Adds a `TTag extends string`
generic so callers can constrain tags to a string-literal union.

## 🧩 Changes

- **Breaking:** remove `Cache.obsoleteRange(predicate)` and `Cache.removeRange(predicate)`.
- Add `CacheSettings.getTags?: (value, ...args) => readonly TTag[]`, recomputed on every successful load.
- Add `Cache.obsoleteByTag(tag)` and `Cache.removeByTag(tag)` with count return values.
- `CacheStateManager` now owns a `tagIndex: Map<string, Set<string>>`, kept in sync on set / remove / LRU eviction / flushAll.
- README + cache changelog updated; cross-node-bus internal doc promoted from spike to PRD v1.
